### PR TITLE
use ImportError when trying to import matplotlib

### DIFF
--- a/contour/contour.py
+++ b/contour/contour.py
@@ -44,7 +44,7 @@ try:
     import matplotlib.pyplot as plt
     from matplotlib.mlab import griddata
     from shapely.geometry import MultiLineString, MultiPolygon
-except:
+except ImportError:
     mplAvailable=False
 
 from frmContour import Ui_ContourDialog


### PR DESCRIPTION
Replace blanket exception statement with a specific error message.
Prevents obscure bugs, such as KeyboardInterrupt being suppressed at
exactly the wrong time