### PR TITLE
#52 second try at fix!

### DIFF
--- a/contour/ContourDialog.py
+++ b/contour/ContourDialog.py
@@ -76,6 +76,10 @@ class ContourDialogPlugin:
             )
             return
 
+        QgsMessageLog.logMessage(
+            f"Contour plugin is using matplotlib version {mpl.__version__} and numpy version {np.__version__}",
+            level=Qgis.Info,
+        )
         self.action = QAction(
             QIcon(":/plugins/contour/contour.png"), "Contour", self._iface.mainWindow()
         )
@@ -208,6 +212,7 @@ class ContourDialog(QDialog, Ui_ContourDialog):
         if self.uSourceLayer.currentIndex() < 0 and self.uSourceLayer.count() == 1:
             self.uSourceLayer.setCurrentIndex(0)
         self.uSourceLayerChanged(self.uSourceLayer.currentLayer())
+        self.reloadData()
 
         # Is MPL version Ok?
         if self._isMPLOk() == False:

--- a/contour/ContourDialog.py
+++ b/contour/ContourDialog.py
@@ -317,10 +317,13 @@ class ContourDialog(QDialog, Ui_ContourDialog):
             self.uSetMaximum.setChecked(fval is not None)
             if fval is not None:
                 self.uMaxContour.setValue(fval)
-            levels = properties.get("Levels").split(";")
+            fval = self._getOptionalValue(properties, "ContourInterval", float)
+            if fval is not None:
+                self.uContourInterval.setValue(fval)
             ival = self._getOptionalValue(properties, "NContour", int)
             if ival is not None:
                 self.uNContour.setValue(ival)
+            levels = properties.get("Levels").split(";")
             self.uLevelsList.clear()
             for level in levels:
                 self.uLevelsList.addItem(level)
@@ -740,6 +743,8 @@ class ContourDialog(QDialog, Ui_ContourDialog):
             "SourceLayerAttr",
             "Mode",
             "Levels",
+            "ContourInterval",
+            "NContour",
             "LabelPrecision",
             "MinContour",
             "MaxContour",

--- a/contour/ContourDialog.py
+++ b/contour/ContourDialog.py
@@ -39,23 +39,25 @@ import math
 import re
 import inspect
 
-mplAvailable=True
+mplAvailable = True
 try:
     import numpy as np
     import matplotlib as mpl
 except ImportError:
-    mplAvailable=False
+    mplAvailable = False
 
 from .ContourDialogUi import Ui_ContourDialog
 
-EPSILON = 1.e-27
-LINES='lines'
-FILLED='filled'
-BOTH='both'
-LAYERS='layer'
+EPSILON = 1.0e-27
+LINES = "lines"
+FILLED = "filled"
+BOTH = "both"
+LAYERS = "layer"
+
 
 def tr(string):
-    return QCoreApplication.translate('Processing', string)
+    return QCoreApplication.translate("Processing", string)
+
 
 class ContourDialogPlugin:
 
@@ -64,13 +66,19 @@ class ContourDialogPlugin:
 
     def initGui(self):
         if not mplAvailable:
-            QMessageBox.warning(self._iface.mainWindow(), tr("Contour error"),
-                tr("The contour plugin is disabled as it requires python modules"
-                " numpy and matplotlib which are not both installed"))
+            QMessageBox.warning(
+                self._iface.mainWindow(),
+                tr("Contour error"),
+                tr(
+                    "The contour plugin is disabled as it requires python modules"
+                    " numpy and matplotlib which are not both installed"
+                ),
+            )
             return
 
-        self.action = QAction(QIcon(":/plugins/contour/contour.png"), \
-        "Contour", self._iface.mainWindow())
+        self.action = QAction(
+            QIcon(":/plugins/contour/contour.png"), "Contour", self._iface.mainWindow()
+        )
         self.action.setWhatsThis(tr("Generate contours based on point vector data"))
         self.action.triggered.connect(self.run)
         self._iface.addToolBarIcon(self.action)
@@ -89,40 +97,43 @@ class ContourDialogPlugin:
             dlg = ContourDialog(self._iface)
             dlg.exec_()
         except ContourError:
-            QMessageBox.warning(self._iface.mainWindow(), tr("Contour error"),
-                str(sys.exc_info()[1]))
+            QMessageBox.warning(
+                self._iface.mainWindow(), tr("Contour error"), str(sys.exc_info()[1])
+            )
 
 
 class ContourDialog(QDialog, Ui_ContourDialog):
 
     class Feedback:
 
-        def __init__( self, messagebar, progress ):
-            self._messageBar=messagebar
-            self._progress=progress
+        def __init__(self, messagebar, progress):
+            self._messageBar = messagebar
+            self._progress = progress
 
-        def isCanceled( self ):
+        def isCanceled(self):
             return False
 
-        def setProgress( self, percent ):
+        def setProgress(self, percent):
             if self._progress:
                 self._progress.setValue(percent)
 
-        def pushInfo( self, info ):
-            self._messageBar.pushInfo('',info)
+        def pushInfo(self, info):
+            self._messageBar.pushInfo("", info)
 
-        def reportError( self, message, fatal=False ):
-            self._messageBar.pushWarning(tr('Error') if fatal else tr('Warning'),message)
+        def reportError(self, message, fatal=False):
+            self._messageBar.pushWarning(
+                tr("Error") if fatal else tr("Warning"), message
+            )
 
     def __init__(self, iface):
         QDialog.__init__(self)
         self._iface = iface
         self._origin = None
         self._loadedDataDef = None
-        self._layer=None
-        self._zField = ''
+        self._layer = None
+        self._zField = ""
         self._loadingLayer = False
-        self._contourId = ''
+        self._contourId = ""
         self._replaceLayerSet = None
         self._canEditList = False
 
@@ -130,7 +141,7 @@ class ContourDialog(QDialog, Ui_ContourDialog):
         self.setupUi(self)
 
         self.uAddButton.setEnabled(False)
-        #re = QRegExp("\\d+\\.?\\d*(?:[Ee][+-]?\\d+)?")
+        # re = QRegExp("\\d+\\.?\\d*(?:[Ee][+-]?\\d+)?")
         self.uLevelsList.setSortingEnabled(False)
         self.uSelectedOnly.setChecked(False)
         self.uSelectedOnly.setEnabled(False)
@@ -149,12 +160,12 @@ class ContourDialog(QDialog, Ui_ContourDialog):
         self.uExtend.setEnabled(False)
         self.progressBar.setValue(0)
         for method in ContourMethod.methods:
-            self.uMethod.addItem(method.name,method.id)
+            self.uMethod.addItem(method.name, method.id)
         for option in ContourExtendOption.options():
-            self.uExtend.addItem(ContourExtendOption.description(option),option)
+            self.uExtend.addItem(ContourExtendOption.description(option), option)
 
-        self._feedback=ContourDialog.Feedback(self.uMessageBar,self.progressBar)
-        self._generator=ContourGenerator(feedback=self._feedback)
+        self._feedback = ContourDialog.Feedback(self.uMessageBar, self.progressBar)
+        self._generator = ContourGenerator(feedback=self._feedback)
 
         self.loadSettings()
 
@@ -162,9 +173,9 @@ class ContourDialog(QDialog, Ui_ContourDialog):
         self.enableContourParams()
         self.enableOkButton()
 
-        #Signals
-        self.uSourceLayer.layerChanged.connect(self.uSourceLayerChanged )
-        self.uDataField.fieldChanged['QString'].connect(self.uDataFieldUpdate)
+        # Signals
+        self.uSourceLayer.layerChanged.connect(self.uSourceLayerChanged)
+        self.uDataField.fieldChanged["QString"].connect(self.uDataFieldUpdate)
         self.uSelectedOnly.toggled.connect(self.reloadData)
         self.uUseGrid.toggled.connect(self._generator.setUseGrid)
         self.uRemoveDuplicates.toggled.connect(self.reloadData)
@@ -190,20 +201,26 @@ class ContourDialog(QDialog, Ui_ContourDialog):
 
         # populate layer list
         if self.uSourceLayer.count() <= 0:
-            raise ContourError(tr("There are no point geometry layers suitable for contouring"))
-        self.setupCurrentLayer( mapCanvas.currentLayer() )
-        if self.uSourceLayer.currentIndex() < 0 and self.uSourceLayer.count()==1:
+            raise ContourError(
+                tr("There are no point geometry layers suitable for contouring")
+            )
+        self.setupCurrentLayer(mapCanvas.currentLayer())
+        if self.uSourceLayer.currentIndex() < 0 and self.uSourceLayer.count() == 1:
             self.uSourceLayer.setCurrentIndex(0)
         self.uSourceLayerChanged(self.uSourceLayer.currentLayer())
-        
+
         # Is MPL version Ok?
         if self._isMPLOk() == False:
-            self.warnUser(tr("You are using an old version matplotlib - only gridded data is supported"))
+            self.warnUser(
+                tr(
+                    "You are using an old version matplotlib - only gridded data is supported"
+                )
+            )
 
-    def warnUser(self,message):
+    def warnUser(self, message):
         self._feedback.reportError(message)
 
-    def adviseUser(self,message):
+    def adviseUser(self, message):
         self._feedback.pushInfo(message)
 
     def closeDialog(self):
@@ -214,19 +231,19 @@ class ContourDialog(QDialog, Ui_ContourDialog):
         """
         Check if matplotlib version > 1.0.0 for contouring fonctions selection
         """
-        version = [int(i) for i in mpl.__version__.split('.')[0:2]]
+        version = [int(i) for i in mpl.__version__.split(".")[0:2]]
         return version >= [1, 0]
 
-    def updatePrecision( self, ndp ):
+    def updatePrecision(self, ndp):
         self.setLabelFormat()
-        ndp=self.uPrecision.value()
+        ndp = self.uPrecision.value()
         if ndp < 0:
-            ndp=4
-        self.uMinContour.setDecimals( ndp )
-        self.uMaxContour.setDecimals( ndp )
-        self.uContourInterval.setDecimals( ndp )
-        self.uContourInterval.setDecimals( ndp )
-        x,y,z=self._generator.data()
+            ndp = 4
+        self.uMinContour.setDecimals(ndp)
+        self.uMaxContour.setDecimals(ndp)
+        self.uContourInterval.setDecimals(ndp)
+        self.uContourInterval.setDecimals(ndp)
+        x, y, z = self._generator.data()
         if z is not None:
             if not self.uSetMinimum.isChecked():
                 self.uMinContour.setValue(np.min(z))
@@ -234,37 +251,37 @@ class ContourDialog(QDialog, Ui_ContourDialog):
                 self.uMaxContour.setValue(np.max(z))
             self.showLevels()
 
-    def _getOptionalValue( self, properties, name, typefunc ):
-        fval=properties.get(name,'')
-        if fval != '':
+    def _getOptionalValue(self, properties, name, typefunc):
+        fval = properties.get(name, "")
+        if fval != "":
             try:
                 return typefunc(fval)
             except:
                 pass
         return None
 
-    def setupCurrentLayer( self, layer ):
+    def setupCurrentLayer(self, layer):
         if not layer:
             return
-        properties = self.getContourProperties( layer )
-        contourId = ''
+        properties = self.getContourProperties(layer)
+        contourId = ""
         sourceLayer = None
         if properties:
-            layerId = properties.get('SourceLayerId')
+            layerId = properties.get("SourceLayerId")
             for l in self.sourceLayers():
                 if l.id() == layerId:
                     sourceLayer = l
                     break
             if sourceLayer:
                 layer = sourceLayer
-                contourId = properties.get('ContourId')
+                contourId = properties.get("ContourId")
         index = self.uSourceLayer.setLayer(layer)
         # If valid existing contour layer, then reset
         if not contourId:
             return
-        layerSet = self.contourLayerSet( contourId )
+        layerSet = self.contourLayerSet(contourId)
         try:
-            attr = properties.get('SourceLayerAttr')
+            attr = properties.get("SourceLayerAttr")
             self.uDataField.setField(attr)
             if FILLED in layerSet:
                 if LINES in layerSet:
@@ -272,40 +289,42 @@ class ContourDialog(QDialog, Ui_ContourDialog):
                 else:
                     self.uFilledContours.setChecked(True)
             elif LAYERS in layerSet:
-                    self.uLayerContours.setChecked(True)
+                self.uLayerContours.setChecked(True)
             else:
                 self.uLinesContours.setChecked(True)
-            index = self.uMethod.findData(properties.get('Method'))
+            index = self.uMethod.findData(properties.get("Method"))
             if index >= 0:
                 self.uMethod.setCurrentIndex(index)
-            index = self.uExtend.findData(properties.get('Extend'))
+            index = self.uExtend.findData(properties.get("Extend"))
             if index >= 0:
                 self.uExtend.setCurrentIndex(index)
-            self.uExtend.setEnabled(self.uFilledContours.isChecked() or self.uBoth.isChecked())
-            self.uPrecision.setValue(int(properties.get('LabelPrecision')))
-            self.uTrimZeros.setChecked(properties.get('TrimZeros') == 'yes' )
-            self.uLabelUnits.setText(properties.get('LabelUnits') or '')
-            self.uApplyColors.setChecked( properties.get('ApplyColors') == 'yes' )
-            ramp=self.stringToColorRamp( properties.get('ColorRamp'))
+            self.uExtend.setEnabled(
+                self.uFilledContours.isChecked() or self.uBoth.isChecked()
+            )
+            self.uPrecision.setValue(int(properties.get("LabelPrecision")))
+            self.uTrimZeros.setChecked(properties.get("TrimZeros") == "yes")
+            self.uLabelUnits.setText(properties.get("LabelUnits") or "")
+            self.uApplyColors.setChecked(properties.get("ApplyColors") == "yes")
+            ramp = self.stringToColorRamp(properties.get("ColorRamp"))
             if ramp:
                 self.uColorRamp.setColorRamp(ramp)
-            self.uReverseRamp.setChecked( properties.get('ReverseRamp') == 'yes' )
-            fval=self._getOptionalValue(properties,'MinContour',float)
-            self.uSetMinimum.setChecked( fval is not None )
+            self.uReverseRamp.setChecked(properties.get("ReverseRamp") == "yes")
+            fval = self._getOptionalValue(properties, "MinContour", float)
+            self.uSetMinimum.setChecked(fval is not None)
             if fval is not None:
                 self.uMinContour.setValue(fval)
-            fval=self._getOptionalValue(properties,'MaxContour',float)
-            self.uSetMaximum.setChecked( fval is not None )
+            fval = self._getOptionalValue(properties, "MaxContour", float)
+            self.uSetMaximum.setChecked(fval is not None)
             if fval is not None:
                 self.uMaxContour.setValue(fval)
-            levels = properties.get('Levels').split(';')
-            ival=self._getOptionalValue(properties,'NContour',int)
+            levels = properties.get("Levels").split(";")
+            ival = self._getOptionalValue(properties, "NContour", int)
             if ival is not None:
                 self.uNContour.setValue(ival)
             self.uLevelsList.clear()
             for level in levels:
                 self.uLevelsList.addItem(level)
-            fval=self._getOptionalValue(properties,'Interval',float)
+            fval = self._getOptionalValue(properties, "Interval", float)
             if fval is not None:
                 self.uContourInterval.setValue(fval)
         finally:
@@ -323,45 +342,51 @@ class ContourDialog(QDialog, Ui_ContourDialog):
             try:
 
                 # Get a default resolution for point thinning
-                extent=self._layer.extent()
-                self._loadingLayer=True
-                haveSelected=self._layer.selectedFeatureCount() > 0
+                extent = self._layer.extent()
+                self._loadingLayer = True
+                haveSelected = self._layer.selectedFeatureCount() > 0
                 self.uSelectedOnly.setChecked(haveSelected)
                 self.uSelectedOnly.setEnabled(haveSelected)
             finally:
-                self._loadingLayer=False
+                self._loadingLayer = False
         self.enableOkButton()
 
     def uDataFieldUpdate(self, inputField):
-        self._zField,isExpression,isValid = self.uDataField.currentField()
+        self._zField, isExpression, isValid = self.uDataField.currentField()
         self.reloadData()
 
-    def dataChanged( self ):
-        x,y,z=self._generator.data()
+    def dataChanged(self):
+        x, y, z = self._generator.data()
         if z is not None:
-            zmin=np.min(z)
-            zmax=np.max(z)
-            ndp=self.uPrecision.value()
-            if zmax-zmin > 0:
-                ndp2=ndp
-                while 10**(-ndp2) > (zmax-zmin)/100 and ndp2 < 10:
+            zmin = np.min(z)
+            zmax = np.max(z)
+            ndp = self.uPrecision.value()
+            if zmax - zmin > 0:
+                ndp2 = ndp
+                while 10 ** (-ndp2) > (zmax - zmin) / 100 and ndp2 < 10:
                     ndp2 += 1
                 if ndp2 != ndp:
                     self.uPrecision.setValue(ndp2)
-                    self.adviseUser(tr("Resetting the label precision to match range of data values"))
+                    self.adviseUser(
+                        tr(
+                            "Resetting the label precision to match range of data values"
+                        )
+                    )
             if not self.uSetMinimum.isChecked():
                 self.uMinContour.setValue(zmin)
             if not self.uSetMaximum.isChecked():
                 self.uMaxContour.setValue(zmax)
-            gridded=self._generator.isGridded()
+            gridded = self._generator.isGridded()
             self.uUseGrid.setEnabled(gridded)
             self.uUseGrid.setChecked(gridded)
             self.uUseGridLabel.setEnabled(gridded)
-            description=tr('Contouring {0} points').format(len(z))
+            description = tr("Contouring {0} points").format(len(z))
             if gridshape is not None:
-                description=description+tr(' in a {0} x {1} grid').format(*gridshape)
+                description = description + tr(" in a {0} x {1} grid").format(
+                    *gridshape
+                )
             else:
-                description=description+' ('+tr('not in regular grid')+')'
+                description = description + " (" + tr("not in regular grid") + ")"
             self.uLayerDescription.setText(description)
         else:
             self.uLayerDescription.setText(tr("No data selected for contouring"))
@@ -369,19 +394,19 @@ class ContourDialog(QDialog, Ui_ContourDialog):
     def reloadData(self):
         if self._loadingLayer:
             return
-        self._loadingLayer=True
+        self._loadingLayer = True
         try:
-            fids=None
+            fids = None
             if self._layer is not None and self.uSelectedOnly.isChecked():
-                fids=self._layer.selectedFeatureIds()
-            self._generator.setDataSource( self._layer, self._zField, fids )
-            duptol=0.0
+                fids = self._layer.selectedFeatureIds()
+            self._generator.setDataSource(self._layer, self._zField, fids)
+            duptol = 0.0
             if self.uRemoveDuplicates.isChecked():
-                duptol=self.uDuplicateTolerance.value()
+                duptol = self.uDuplicateTolerance.value()
             self._generator.setDuplicatePointTolerance(duptol)
             self.dataChanged()
         finally:
-            self._loadingLayer=False
+            self._loadingLayer = False
         self._replaceLayerSet = None
         if not self._layer or not self._zField:
             self.enableOkButton()
@@ -392,42 +417,49 @@ class ContourDialog(QDialog, Ui_ContourDialog):
 
     def updateOutputName(self):
         if self._layer.name() and self._zField:
-            zf=self._zField
-            if re.search(r'\W',zf):
-                zf='expr'
-            self.uOutputName.setText("%s_%s"%(self._layer.name(), zf ))
+            zf = self._zField
+            if re.search(r"\W", zf):
+                zf = "expr"
+            self.uOutputName.setText("%s_%s" % (self._layer.name(), zf))
 
     def editLevel(self, item=None):
         if not self._canEditList:
             return
         if item is None or QApplication.keyboardModifiers() & Qt.ShiftModifier:
             list = self.uLevelsList
-            val=' '.join([list.item(i).text() for i in range(0, list.count())])
+            val = " ".join([list.item(i).text() for i in range(0, list.count())])
         else:
             val = item.text()
-        newval, ok = QInputDialog.getText(self, tr("Update level"), 
-                         tr("Enter a single level to replace this one")+"\n"+
-                         tr("or a space separated list of levels to replace all"),
-                         QLineEdit.Normal,
-                         val)
+        newval, ok = QInputDialog.getText(
+            self,
+            tr("Update level"),
+            tr("Enter a single level to replace this one")
+            + "\n"
+            + tr("or a space separated list of levels to replace all"),
+            QLineEdit.Normal,
+            val,
+        )
         if ok:
-            values=newval.split()
-            fval=[]
+            values = newval.split()
+            fval = []
             for v in values:
                 try:
                     fval.append(float(v))
                 except:
-                    QMessageBox.warning(self._iface.mainWindow(), tr("Contour error"),
-                                        tr("Invalid contour value {0}").format(v))
+                    QMessageBox.warning(
+                        self._iface.mainWindow(),
+                        tr("Contour error"),
+                        tr("Invalid contour value {0}").format(v),
+                    )
                     return
             if len(values) < 1:
                 return
-            if len(values) == 1: 
+            if len(values) == 1:
                 item.setText(newval)
                 self.enableOkButton()
             else:
                 values.sort(key=float)
-                index=self.uMethod.findData('manual')
+                index = self.uMethod.findData("manual")
                 if index >= 0:
                     self.uMethod.setCurrentIndex(index)
                 self.uNContour.setValue(len(values))
@@ -435,98 +467,102 @@ class ContourDialog(QDialog, Ui_ContourDialog):
                 for v in values:
                     self.uLevelsList.addItem(v)
 
-            fval=self.getLevels()
+            fval = self.getLevels()
             self._generator.setContourLevels(fval)
             self.enableOkButton()
 
-    def getMethod( self ):
-        index=self.uMethod.currentIndex()
-        methodid=self.uMethod.itemData(index)
+    def getMethod(self):
+        index = self.uMethod.currentIndex()
+        methodid = self.uMethod.itemData(index)
         return ContourMethod.getMethod(methodid)
 
-    def contourLevelParams( self ):
-        method=self.getMethod()
-        ncontour=self.uNContour.value()
-        interval=self.uContourInterval.value()
-        zmin=None
-        zmax=None
+    def contourLevelParams(self):
+        method = self.getMethod()
+        ncontour = self.uNContour.value()
+        interval = self.uContourInterval.value()
+        zmin = None
+        zmax = None
         if self.uSetMinimum.isChecked():
-            zmin=self.uMinContour.value()
+            zmin = self.uMinContour.value()
         if self.uSetMaximum.isChecked():
-            zmax=self.uMaxContour.value()
-        list=self.uLevelsList
-        levels=' '.join([list.item(i).text() for i in range(0, list.count())])
-        params={
-            'min': zmin,
-            'max': zmax,
-            'interval': interval,
-            'ncontour': ncontour,
-            'maxcontour': ncontour,
-            'mantissa': None,
-            'levels': levels
-            }
+            zmax = self.uMaxContour.value()
+        list = self.uLevelsList
+        levels = " ".join([list.item(i).text() for i in range(0, list.count())])
+        params = {
+            "min": zmin,
+            "max": zmax,
+            "interval": interval,
+            "ncontour": ncontour,
+            "maxcontour": ncontour,
+            "mantissa": None,
+            "levels": levels,
+        }
         return method.id, params
 
-    def enableContourParams( self ):
-        method=self.getMethod()
-        params=[]
+    def enableContourParams(self):
+        method = self.getMethod()
+        params = []
         if method is not None:
-            params=list(method.required)
+            params = list(method.required)
             params.extend(method.optional)
-        self.uContourInterval.setEnabled( 'interval' in params )
-        self.uNContour.setEnabled( 'ncontour' in params or 'maxcontour' in params )
-        self.uSetMinimum.setEnabled( 'min' in params )
-        self.uMinContour.setEnabled( 'min' in params and self.uSetMinimum.isChecked() )
-        self.uSetMaximum.setEnabled( 'max' in params )
-        self.uMaxContour.setEnabled( 'max' in params and self.uSetMaximum.isChecked() )
-        self._canEditList='levels' in params
+        self.uContourInterval.setEnabled("interval" in params)
+        self.uNContour.setEnabled("ncontour" in params or "maxcontour" in params)
+        self.uSetMinimum.setEnabled("min" in params)
+        self.uMinContour.setEnabled("min" in params and self.uSetMinimum.isChecked())
+        self.uSetMaximum.setEnabled("max" in params)
+        self.uMaxContour.setEnabled("max" in params and self.uSetMaximum.isChecked())
+        self._canEditList = "levels" in params
 
-    def toggleSetMinimum( self ):
+    def toggleSetMinimum(self):
         self.uMinContour.setEnabled(self.uSetMinimum.isChecked())
         if not self.uSetMinimum.isChecked():
-            x,y,z = self._generator.data()
+            x, y, z = self._generator.data()
             if z is not None:
                 self.uMinContour.setValue(np.min(z))
                 self.computeLevels()
 
-    def toggleSetMaximum( self ):
+    def toggleSetMaximum(self):
         self.uMaxContour.setEnabled(self.uSetMaximum.isChecked())
         if not self.uSetMaximum.isChecked():
-            x,y,z = self._generator.data()
+            x, y, z = self._generator.data()
             if z is not None:
                 self.uMaxContour.setValue(np.max(z))
                 self.computeLevels()
 
     def computeLevels(self):
         # Use ContourGenerator code
-        methodcode,params=self.contourLevelParams()
-        self._generator.setContourMethod(methodcode,params)
+        methodcode, params = self.contourLevelParams()
+        self._generator.setContourMethod(methodcode, params)
         self.showLevels()
         self.enableOkButton()
 
     def showLevels(self):
         self.uLevelsList.clear()
         try:
-            levels=self._generator.levels()
+            levels = self._generator.levels()
             # Need to create some contours if manual and none
             # defined
             if self._canEditList and len(levels) == 0:
-                x,y,z=self._generator.data()
+                x, y, z = self._generator.data()
                 if z is not None:
-                    ncontour=self.uNContour.value()
+                    ncontour = self.uNContour.value()
                     try:
-                        levels=ContourMethod.calculateLevels(z,'equal',ncontour=ncontour)
+                        levels = ContourMethod.calculateLevels(
+                            z, "equal", ncontour=ncontour
+                        )
                     except:
-                        levels=[0.0]
-        except (ContourMethodError,ContourError) as ex:
+                        levels = [0.0]
+        except (ContourMethodError, ContourError) as ex:
             self._feedback.pushInfo(ex.message())
             return
         for i in range(0, len(levels)):
             self.uLevelsList.addItem(self.formatLevel(levels[i]))
 
-    def modeToggled(self,enabled):
+    def modeToggled(self, enabled):
         if enabled:
-            self.uExtend.setEnabled(self.uFilledContours.isChecked() or self.uBoth.isChecked())
+            self.uExtend.setEnabled(
+                self.uFilledContours.isChecked() or self.uBoth.isChecked()
+            )
             self.enableOkButton()
 
     def enableOkButton(self):
@@ -537,20 +573,29 @@ class ContourDialog(QDialog, Ui_ContourDialog):
         except:
             pass
 
-    def confirmReplaceSet(self,set):
-        message = (tr("The following layers already have contours of {0}").format(self._zField) + "\n"
-                    + tr("Do you want to replace them with the new contours?")+"\n\n")
+    def confirmReplaceSet(self, set):
+        message = (
+            tr("The following layers already have contours of {0}").format(self._zField)
+            + "\n"
+            + tr("Do you want to replace them with the new contours?")
+            + "\n\n"
+        )
 
         for layer in list(set.values()):
             message = message + "\n   " + layer.name()
-        return QMessageBox.question(self,tr("Replace contour layers"),message,
-                             QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel, QMessageBox.Cancel)
+        return QMessageBox.question(
+            self,
+            tr("Replace contour layers"),
+            message,
+            QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel,
+            QMessageBox.Cancel,
+        )
 
     def addContours(self):
         try:
             self.validate()
             self._contourId = QDateTime.currentDateTime().toString("yyyyMMddhhmmss")
-            replaceContourId = ''
+            replaceContourId = ""
             for set in self.candidateReplacementSets():
                 result = self.confirmReplaceSet(set)
                 if result == QMessageBox.Cancel:
@@ -568,37 +613,44 @@ class ContourDialog(QDialog, Ui_ContourDialog):
                     self.makeContourLayer(ContourType.filled)
                 if self.uLayerContours.isChecked():
                     self.makeContourLayer(ContourType.layer)
-                oldLayerSet = self.contourLayerSet( replaceContourId )
+                oldLayerSet = self.contourLayerSet(replaceContourId)
                 if oldLayerSet:
                     for layer in list(oldLayerSet.values()):
-                        QgsProject.instance().removeMapLayer( layer.id() )
+                        QgsProject.instance().removeMapLayer(layer.id())
                 self._replaceLayerSet = self.contourLayerSet(self._contourId)
             finally:
                 QApplication.restoreOverrideCursor()
 
         except ContourGenerationError as cge:
-            self.warnUser(tr("Exception encountered: ") + str(cge) +" "+tr("(Try removing duplicate points)"))
+            self.warnUser(
+                tr("Exception encountered: ")
+                + str(cge)
+                + " "
+                + tr("(Try removing duplicate points)")
+            )
         except ContourError as ce:
             self.warnUser(tr("Error calculating grid/contours: {0}").format(ce))
         # self.uAddButton.setEnabled(False)
 
     def showHelp(self):
         file = os.path.realpath(__file__)
-        file = os.path.join(os.path.dirname(file),'doc','ContourDialog.html')
+        file = os.path.join(os.path.dirname(file), "doc", "ContourDialog.html")
         QDesktopServices.openUrl(QUrl.fromLocalFile(file))
 
     def validate(self):
         message = None
         if self.uSourceLayer.currentLayer() is None:
             message = tr("Please specify vector layer")
-        if (self.uDataField.currentText() == ""):
+        if self.uDataField.currentText() == "":
             message = tr("Please specify data field")
         if message != None:
             raise ContourError(message)
 
     def sourceLayers(self):
         for layer in list(QgsProject.instance().mapLayers().values()):
-            if (layer.type() == layer.VectorLayer) and (layer.geometryType() == QgsWkbTypes.PointGeometry):
+            if (layer.type() == layer.VectorLayer) and (
+                layer.geometryType() == QgsWkbTypes.PointGeometry
+            ):
                 yield layer
 
     def getLevels(self):
@@ -617,7 +669,7 @@ class ContourDialog(QDialog, Ui_ContourDialog):
         pl.deleteAttributes(pl.attributeIndexes())
         layer.updateFields()
 
-    def createVectorLayer(self, type, name, mode,fields,crs):
+    def createVectorLayer(self, type, name, mode, fields, crs):
         layer = None
         if self._replaceLayerSet:
             layer = self._replaceLayerSet.get(mode)
@@ -625,37 +677,41 @@ class ContourDialog(QDialog, Ui_ContourDialog):
         if layer:
             self.clearLayer(layer)
         else:
-            url=QgsWkbTypes.displayString(type)+'?crs=internal:'+str(crs.srsid())
+            url = QgsWkbTypes.displayString(type) + "?crs=internal:" + str(crs.srsid())
             layer = QgsVectorLayer(url, name, "memory")
 
         if layer is None:
             raise ContourError(tr("Could not create layer for contours"))
 
         pr = layer.dataProvider()
-        pr.addAttributes( fields )
+        pr.addAttributes(fields)
         layer.updateFields()
 
         layer.setCrs(crs, False)
         levels = ";".join(map(str, self.getLevels()))
         properties = {
-            'ContourId' : self._contourId,
-            'SourceLayerId' : self._layer.id(),
-            'SourceLayerAttr' : self._zField,
-            'Mode' : mode,
-            'Levels' : levels,
-            'LabelPrecision' : str(self.uPrecision.value()),
-            'TrimZeros' : 'yes' if self.uTrimZeros.isChecked() else 'no',
-            'LabelUnits' : str(self.uLabelUnits.text()),
-            'NContour' : str(self.uNContour.value()),
-            'MinContour' : str(self.uMinContour.value()) if self.uSetMinimum.isChecked() else '',
-            'MaxContour' : str(self.uMaxContour.value()) if self.uSetMaximum.isChecked() else '',
-            'Extend' : self.uExtend.itemData(self.uExtend.currentIndex()),
-            'Method' : self.uMethod.itemData(self.uMethod.currentIndex()),
-            'ApplyColors' : 'yes' if self.uApplyColors.isChecked() else 'no',
-            'ColorRamp' : self.colorRampToString( self.uColorRamp.colorRamp()),
-            'ReverseRamp' : 'yes' if self.uReverseRamp.isChecked() else 'no',
-            'ContourInterval' : str(self.uContourInterval.value()),
-            }
+            "ContourId": self._contourId,
+            "SourceLayerId": self._layer.id(),
+            "SourceLayerAttr": self._zField,
+            "Mode": mode,
+            "Levels": levels,
+            "LabelPrecision": str(self.uPrecision.value()),
+            "TrimZeros": "yes" if self.uTrimZeros.isChecked() else "no",
+            "LabelUnits": str(self.uLabelUnits.text()),
+            "NContour": str(self.uNContour.value()),
+            "MinContour": (
+                str(self.uMinContour.value()) if self.uSetMinimum.isChecked() else ""
+            ),
+            "MaxContour": (
+                str(self.uMaxContour.value()) if self.uSetMaximum.isChecked() else ""
+            ),
+            "Extend": self.uExtend.itemData(self.uExtend.currentIndex()),
+            "Method": self.uMethod.itemData(self.uMethod.currentIndex()),
+            "ApplyColors": "yes" if self.uApplyColors.isChecked() else "no",
+            "ColorRamp": self.colorRampToString(self.uColorRamp.colorRamp()),
+            "ReverseRamp": "yes" if self.uReverseRamp.isChecked() else "no",
+            "ContourInterval": str(self.uContourInterval.value()),
+        }
         self.setContourProperties(layer, properties)
         return layer
 
@@ -664,37 +720,37 @@ class ContourDialog(QDialog, Ui_ContourDialog):
         if not registry.mapLayer(layer.id()):
             registry.addMapLayer(layer)
         else:
-            node=QgsProject.instance().layerTreeRoot().findLayer(layer.id())
+            node = QgsProject.instance().layerTreeRoot().findLayer(layer.id())
             if node is not None:
                 node.setItemVisibilityChecked(True)
             layer.triggerRepaint()
             self._iface.mapCanvas().refresh()
 
-    def setContourProperties( self, layer, properties ):
+    def setContourProperties(self, layer, properties):
         for key in list(properties.keys()):
-            layer.setCustomProperty('ContourPlugin.'+key, properties[key])
+            layer.setCustomProperty("ContourPlugin." + key, properties[key])
 
-    def getContourProperties( self, layer ):
+    def getContourProperties(self, layer):
         if layer.type() != layer.VectorLayer or layer.dataProvider().name() != "memory":
             return None
         properties = {}
         for key in [
-            'ContourId',
-            'SourceLayerId',
-            'SourceLayerAttr',
-            'Mode',
-            'Levels',
-            'LabelPrecision',
-            'MinContour',
-            'MaxContour',
-            'Extend',
-            'Method',
-            'ApplyColors',
-            'ColorRamp',
-            'ReverseRamp'
-            ]:
-            properties[key] = str(layer.customProperty('ContourPlugin.'+key))
-        if not properties['ContourId']:
+            "ContourId",
+            "SourceLayerId",
+            "SourceLayerAttr",
+            "Mode",
+            "Levels",
+            "LabelPrecision",
+            "MinContour",
+            "MaxContour",
+            "Extend",
+            "Method",
+            "ApplyColors",
+            "ColorRamp",
+            "ReverseRamp",
+        ]:
+            properties[key] = str(layer.customProperty("ContourPlugin." + key))
+        if not properties["ContourId"]:
             return None
         return properties
 
@@ -711,20 +767,22 @@ class ContourDialog(QDialog, Ui_ContourDialog):
             if ok:
                 yield layer
 
-    def contourLayerSet( self, contourId ):
-        layers = self.contourLayers({'ContourId':contourId} )
-        layerSet={}
+    def contourLayerSet(self, contourId):
+        layers = self.contourLayers({"ContourId": contourId})
+        layerSet = {}
         for layer in layers:
             properties = self.getContourProperties(layer)
-            layerSet[properties.get('Mode')] = layer
+            layerSet[properties.get("Mode")] = layer
         return layerSet
 
-    def layerSetContourId( self, layerSet ):
+    def layerSetContourId(self, layerSet):
         if layerSet:
-            return self.getContourProperties(list(layerSet.values())[0]).get('ContourId')
+            return self.getContourProperties(list(layerSet.values())[0]).get(
+                "ContourId"
+            )
         return None
 
-    def candidateReplacementSets( self ):
+    def candidateReplacementSets(self):
         # Note: use _replaceLayerSet first as this will be the layer
         # set that the contour dialog was opened with. Following this
         # look for any other potential layers.
@@ -735,241 +793,266 @@ class ContourDialog(QDialog, Ui_ContourDialog):
             ids.append(self.layerSetContourId(set))
             yield set
 
-        for layer in self.contourLayers({
-            'SourceLayerId' : self._layer.id(),
-            'SourceLayerAttr' : self._zField } ):
-            id = self.getContourProperties(layer).get('ContourId')
+        for layer in self.contourLayers(
+            {"SourceLayerId": self._layer.id(), "SourceLayerAttr": self._zField}
+        ):
+            id = self.getContourProperties(layer).get("ContourId")
             if id in ids:
                 continue
             ids.append(id)
             yield self.contourLayerSet(id)
 
-    def makeContourLayer(self,ctype):
+    def makeContourLayer(self, ctype):
         try:
             self._generator.setContourType(ctype)
-            extend=self.uExtend.itemData(self.uExtend.currentIndex())
+            extend = self.uExtend.itemData(self.uExtend.currentIndex())
             self._generator.setContourExtendOption(extend)
             name = self.uOutputName.text()
-            fields=self._generator.fields()
-            geomtype=self._generator.wkbtype()
-            crs=self._generator.crs()
-            vl = self.createVectorLayer(geomtype, name, ctype,fields,crs)
-            levels=[]
+            fields = self._generator.fields()
+            geomtype = self._generator.wkbtype()
+            crs = self._generator.crs()
+            vl = self.createVectorLayer(geomtype, name, ctype, fields, crs)
+            levels = []
             vl.startEditing()
             for feature in self._generator.contourFeatures():
-                vl.addFeature( feature )
-                levels.append((feature['index'],feature['label']))
+                vl.addFeature(feature)
+                levels.append((feature["index"], feature["label"]))
             vl.updateExtents()
             vl.commitChanges()
-        except (ContourError,ContourMethodError) as ex:
+        except (ContourError, ContourMethodError) as ex:
             self.warnUser(ex.message())
             return
         try:
             if len(levels) > 0:
-                rendtype='line' if ctype == ContourType.line else 'polygon'
-                self.applyRenderer(vl,rendtype,levels)
+                rendtype = "line" if ctype == ContourType.line else "polygon"
+                self.applyRenderer(vl, rendtype, levels)
         except:
             self.warnUser("Error rendering contour layer")
         self.addLayer(vl)
         self.adviseUser(tr("Contour layer {0} created").format(vl.name()))
 
-    def dataChanged( self ):
-        x,y,z=self._generator.data()
+    def dataChanged(self):
+        x, y, z = self._generator.data()
         if z is not None:
-            zmin=np.min(z)
-            zmax=np.max(z)
-            ndp=self.uPrecision.value()
-            if zmax-zmin > 0:
-                ndp2=ndp
-                while 10**(-ndp2) > (zmax-zmin)/100 and ndp2 < 10:
+            zmin = np.min(z)
+            zmax = np.max(z)
+            ndp = self.uPrecision.value()
+            if zmax - zmin > 0:
+                ndp2 = ndp
+                while 10 ** (-ndp2) > (zmax - zmin) / 100 and ndp2 < 10:
                     ndp2 += 1
                 if ndp2 != ndp:
                     self.uPrecision.setValue(ndp2)
-                    self.adviseUser(tr("Resetting the label precision to match range of data values"))
+                    self.adviseUser(
+                        tr(
+                            "Resetting the label precision to match range of data values"
+                        )
+                    )
             if not self.uSetMinimum.isChecked():
                 self.uMinContour.setValue(zmin)
             if not self.uSetMaximum.isChecked():
                 self.uMaxContour.setValue(zmax)
-            gridded=self._generator.isGridded()
+            gridded = self._generator.isGridded()
             self.uUseGrid.setEnabled(gridded)
             self.uUseGrid.setChecked(gridded)
             self.uUseGridLabel.setEnabled(gridded)
-            description='Contouring {0} points'.format(len(z))
+            description = "Contouring {0} points".format(len(z))
             if gridded:
-                gridshape=self._generator.gridShape()
-                description=description+' in a {0} x {1} grid'.format(*gridshape)
+                gridshape = self._generator.gridShape()
+                description = description + " in a {0} x {1} grid".format(*gridshape)
             else:
-                description=description+' (not in regular grid)'
+                description = description + " (not in regular grid)"
             self.uLayerDescription.setText(description)
         else:
             self.uLayerDescription.setText(tr("No data selected for contouring"))
 
-    def setLabelFormat( self ):
-        ndp=self.uPrecision.value()
-        trim=self.uTrimZeros.isChecked()
-        units=self.uLabelUnits.text()
-        self._generator.setLabelFormat(ndp,trim,units)
+    def setLabelFormat(self):
+        ndp = self.uPrecision.value()
+        trim = self.uTrimZeros.isChecked()
+        units = self.uLabelUnits.text()
+        self._generator.setLabelFormat(ndp, trim, units)
 
-    def formatLevel( self, level ):
+    def formatLevel(self, level):
         return self._generator.formatLevel(level)
 
-    def applyRenderer( self, layer, type, levels ):
+    def applyRenderer(self, layer, type, levels):
         if not self.uApplyColors.isChecked():
             return
-        ramp=self.uColorRamp.colorRamp()
-        reversed=self.uReverseRamp.isChecked()
+        ramp = self.uColorRamp.colorRamp()
+        reversed = self.uReverseRamp.isChecked()
         if ramp is None:
             return
-        nLevels=len(levels)
+        nLevels = len(levels)
         if nLevels < 2:
             return
-        renderer=QgsCategorizedSymbolRenderer('index')
+        renderer = QgsCategorizedSymbolRenderer("index")
         for i, level in enumerate(levels):
-            value,label=level
-            rampvalue=float(i)/(nLevels-1)
+            value, label = level
+            rampvalue = float(i) / (nLevels - 1)
             if reversed:
-                rampvalue=1.0-rampvalue
-            color=ramp.color(rampvalue)
-            symbol=None
-            if type=='line':
-                symbol=QgsLineSymbol.createSimple({})
+                rampvalue = 1.0 - rampvalue
+            color = ramp.color(rampvalue)
+            symbol = None
+            if type == "line":
+                symbol = QgsLineSymbol.createSimple({})
             else:
-                symbol=QgsFillSymbol.createSimple({'outline_style':'no'})
+                symbol = QgsFillSymbol.createSimple({"outline_style": "no"})
             symbol.setColor(color)
-            category=QgsRendererCategory(value,symbol,label)
+            category = QgsRendererCategory(value, symbol, label)
             renderer.addCategory(category)
         layer.setRenderer(renderer)
 
-    def colorRampToString( self, ramp ):
+    def colorRampToString(self, ramp):
         if ramp is None:
-            return '';
-        d=QDomDocument()
-        d.appendChild(QgsSymbolLayerUtils.saveColorRamp('ramp',ramp,d))
-        rampdef=d.toString()
+            return ""
+        d = QDomDocument()
+        d.appendChild(QgsSymbolLayerUtils.saveColorRamp("ramp", ramp, d))
+        rampdef = d.toString()
         return rampdef
 
-    def stringToColorRamp( self, rampdef ):
+    def stringToColorRamp(self, rampdef):
         try:
-            if '<' not in rampdef:
+            if "<" not in rampdef:
                 return None
-            d=QDomDocument()
+            d = QDomDocument()
             d.setContent(rampdef)
-            return QgsSymbolLayerUtils.loadColorRamp( d.documentElement() )
+            return QgsSymbolLayerUtils.loadColorRamp(d.documentElement())
         except:
             return None
 
-    def saveSettings( self ):
-        settings=QSettings()
-        base='/plugins/contour/'
-        mode=(LAYERS if self.uLayerContours.isChecked() else
-              BOTH if self.uBoth.isChecked() else
-              FILLED if self.uFilledContours.isChecked() else
-              LINES)
-        list=self.uLevelsList
-        values=' '.join([list.item(i).text() for i in range(0, list.count())])
-        settings.setValue(base+'mode',mode)
-        settings.setValue(base+'levels',str(self.uNContour.value()))
-        settings.setValue(base+'values',values)
-        settings.setValue(base+'interval',str(self.uContourInterval.value()))
-        settings.setValue(base+'extend',self.uExtend.itemData(self.uExtend.currentIndex()))
-        settings.setValue(base+'method',self.uMethod.itemData(self.uMethod.currentIndex()))
-        settings.setValue(base+'precision',str(self.uPrecision.value()))
-        settings.setValue(base+'setmin','yes' if self.uSetMinimum.isChecked() else 'no')
-        settings.setValue(base+'minval',str(self.uMinContour.value()))
-        settings.setValue(base+'setmax','yes' if self.uSetMaximum.isChecked() else 'no')
-        settings.setValue(base+'maxval',str(self.uMaxContour.value()))
-        settings.setValue(base+'trimZeros','yes' if self.uTrimZeros.isChecked() else 'no')
-        settings.setValue(base+'units',self.uLabelUnits.text())
-        settings.setValue(base+'applyColors','yes' if self.uApplyColors.isChecked() else 'no')
-        settings.setValue(base+'ramp',self.colorRampToString(self.uColorRamp.colorRamp()))
-        settings.setValue(base+'reverseRamp','yes' if self.uReverseRamp.isChecked() else 'no')
-        settings.setValue(base+'dialogWidth',str(self.width()))
-        settings.setValue(base+'dialogHeight',str(self.height()))
+    def saveSettings(self):
+        settings = QSettings()
+        base = "/plugins/contour/"
+        mode = (
+            LAYERS
+            if self.uLayerContours.isChecked()
+            else (
+                BOTH
+                if self.uBoth.isChecked()
+                else FILLED if self.uFilledContours.isChecked() else LINES
+            )
+        )
+        list = self.uLevelsList
+        values = " ".join([list.item(i).text() for i in range(0, list.count())])
+        settings.setValue(base + "mode", mode)
+        settings.setValue(base + "levels", str(self.uNContour.value()))
+        settings.setValue(base + "values", values)
+        settings.setValue(base + "interval", str(self.uContourInterval.value()))
+        settings.setValue(
+            base + "extend", self.uExtend.itemData(self.uExtend.currentIndex())
+        )
+        settings.setValue(
+            base + "method", self.uMethod.itemData(self.uMethod.currentIndex())
+        )
+        settings.setValue(base + "precision", str(self.uPrecision.value()))
+        settings.setValue(
+            base + "setmin", "yes" if self.uSetMinimum.isChecked() else "no"
+        )
+        settings.setValue(base + "minval", str(self.uMinContour.value()))
+        settings.setValue(
+            base + "setmax", "yes" if self.uSetMaximum.isChecked() else "no"
+        )
+        settings.setValue(base + "maxval", str(self.uMaxContour.value()))
+        settings.setValue(
+            base + "trimZeros", "yes" if self.uTrimZeros.isChecked() else "no"
+        )
+        settings.setValue(base + "units", self.uLabelUnits.text())
+        settings.setValue(
+            base + "applyColors", "yes" if self.uApplyColors.isChecked() else "no"
+        )
+        settings.setValue(
+            base + "ramp", self.colorRampToString(self.uColorRamp.colorRamp())
+        )
+        settings.setValue(
+            base + "reverseRamp", "yes" if self.uReverseRamp.isChecked() else "no"
+        )
+        settings.setValue(base + "dialogWidth", str(self.width()))
+        settings.setValue(base + "dialogHeight", str(self.height()))
 
-    def loadSettings( self ):
-        settings=QSettings()
-        base='/plugins/contour/'
+    def loadSettings(self):
+        settings = QSettings()
+        base = "/plugins/contour/"
         try:
-            mode=settings.value(base+'mode')
-            if mode==LAYERS:
+            mode = settings.value(base + "mode")
+            if mode == LAYERS:
                 self.uLayerContours.setChecked(True)
-            elif mode==BOTH:
+            elif mode == BOTH:
                 self.uBoth.setChecked(True)
-            elif mode==FILLED:
+            elif mode == FILLED:
                 self.uFilledContours.setChecked(True)
             else:
                 self.uLinesContours.setChecked(True)
 
-            levels=settings.value(base+'levels')
+            levels = settings.value(base + "levels")
             if levels is not None and levels.isdigit():
                 self.uNContour.setValue(int(levels))
 
-            values=settings.value(base+'values')
+            values = settings.value(base + "values")
             if values is not None:
                 self.uLevelsList.clear()
                 for value in values.split():
                     self.uLevelsList.addItem(value)
 
-            setmin=settings.value(base+'setmin') == 'yes'
+            setmin = settings.value(base + "setmin") == "yes"
             self.uSetMinimum.setChecked(setmin)
             if setmin:
                 try:
-                    value=settings.value(base+'minval')
+                    value = settings.value(base + "minval")
                     self.uMinContour.setValue(float(value))
                 except:
                     pass
 
-            setmax=settings.value(base+'setmax') == 'yes'
+            setmax = settings.value(base + "setmax") == "yes"
             self.uSetMaximum.setChecked(setmax)
             if setmax:
                 try:
-                    value=settings.value(base+'maxval')
+                    value = settings.value(base + "maxval")
                     self.uMaxContour.setValue(float(value))
                 except:
                     pass
 
-            extend=settings.value(base+'extend')
+            extend = settings.value(base + "extend")
             index = self.uExtend.findData(extend)
             if index >= 0:
                 self.uExtend.setCurrentIndex(index)
 
-            method=settings.value(base+'method')
+            method = settings.value(base + "method")
             index = self.uMethod.findData(method)
             if index >= 0:
                 self.uMethod.setCurrentIndex(index)
 
-            precision=settings.value(base+'precision')
+            precision = settings.value(base + "precision")
             if precision is not None and precision.isdigit():
-                ndp=int(precision)
+                ndp = int(precision)
                 self.uPrecision.setValue(ndp)
-                self.uMinContour.setDecimals( ndp )
-                self.uMaxContour.setDecimals( ndp )
+                self.uMinContour.setDecimals(ndp)
+                self.uMaxContour.setDecimals(ndp)
 
-            units=settings.value(base+'units')
+            units = settings.value(base + "units")
             if units is not None:
                 self.uLabelUnits.setText(units)
 
-            applyColors=settings.value(base+'applyColors')
-            self.uApplyColors.setChecked(applyColors=='yes')
+            applyColors = settings.value(base + "applyColors")
+            self.uApplyColors.setChecked(applyColors == "yes")
 
-            ramp=settings.value(base+'ramp')
-            ramp=self.stringToColorRamp(ramp)
+            ramp = settings.value(base + "ramp")
+            ramp = self.stringToColorRamp(ramp)
             if ramp:
                 self.uColorRamp.setColorRamp(ramp)
 
-            reverseRamp=settings.value(base+'reverseRamp')
-            self.uReverseRamp.setChecked(reverseRamp=='yes')
+            reverseRamp = settings.value(base + "reverseRamp")
+            self.uReverseRamp.setChecked(reverseRamp == "yes")
 
-            trimZeros=settings.value(base+'trimZeros')
-            self.uTrimZeros.setChecked(trimZeros=='yes')
+            trimZeros = settings.value(base + "trimZeros")
+            self.uTrimZeros.setChecked(trimZeros == "yes")
 
-            width=settings.value(base+'dialogWidth')
-            height=settings.value(base+'dialogHeight')
+            width = settings.value(base + "dialogWidth")
+            height = settings.value(base + "dialogHeight")
             if width is not None and height is not None:
                 try:
-                    width=int(width)
-                    height=int(height)
-                    self.resize(width,height)
+                    width = int(width)
+                    height = int(height)
+                    self.resize(width, height)
                 except:
                     pass
         except:

--- a/contour/ContourDialogUi.py
+++ b/contour/ContourDialogUi.py
@@ -8,6 +8,7 @@
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
+
 class Ui_ContourDialog(object):
     def setupUi(self, ContourDialog):
         ContourDialog.setObjectName("ContourDialog")
@@ -30,7 +31,9 @@ class Ui_ContourDialog(object):
         self.gridLayout = QtWidgets.QGridLayout(self.groupBox_2)
         self.gridLayout.setObjectName("gridLayout")
         self.formLayout_2 = QtWidgets.QFormLayout()
-        self.formLayout_2.setFieldGrowthPolicy(QtWidgets.QFormLayout.AllNonFixedFieldsGrow)
+        self.formLayout_2.setFieldGrowthPolicy(
+            QtWidgets.QFormLayout.AllNonFixedFieldsGrow
+        )
         self.formLayout_2.setContentsMargins(-1, 0, -1, -1)
         self.formLayout_2.setObjectName("formLayout_2")
         self.label_3 = QtWidgets.QLabel(self.groupBox_2)
@@ -38,7 +41,9 @@ class Ui_ContourDialog(object):
         self.formLayout_2.setWidget(1, QtWidgets.QFormLayout.LabelRole, self.label_3)
         self.uSourceLayer = QgsMapLayerComboBox(self.groupBox_2)
         self.uSourceLayer.setObjectName("uSourceLayer")
-        self.formLayout_2.setWidget(1, QtWidgets.QFormLayout.FieldRole, self.uSourceLayer)
+        self.formLayout_2.setWidget(
+            1, QtWidgets.QFormLayout.FieldRole, self.uSourceLayer
+        )
         self.label_4 = QtWidgets.QLabel(self.groupBox_2)
         self.label_4.setObjectName("label_4")
         self.formLayout_2.setWidget(3, QtWidgets.QFormLayout.LabelRole, self.label_4)
@@ -47,7 +52,9 @@ class Ui_ContourDialog(object):
         self.formLayout_2.setWidget(3, QtWidgets.QFormLayout.FieldRole, self.uDataField)
         self.uSelectedOnly = QtWidgets.QCheckBox(self.groupBox_2)
         self.uSelectedOnly.setObjectName("uSelectedOnly")
-        self.formLayout_2.setWidget(4, QtWidgets.QFormLayout.FieldRole, self.uSelectedOnly)
+        self.formLayout_2.setWidget(
+            4, QtWidgets.QFormLayout.FieldRole, self.uSelectedOnly
+        )
         self.gridLayout.addLayout(self.formLayout_2, 1, 0, 1, 1)
         self.horizontalLayout = QtWidgets.QHBoxLayout()
         self.horizontalLayout.setObjectName("horizontalLayout")
@@ -77,7 +84,9 @@ class Ui_ContourDialog(object):
         self.uUseGrid.setText("")
         self.uUseGrid.setObjectName("uUseGrid")
         self.horizontalLayout.addWidget(self.uUseGrid)
-        spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+        spacerItem = QtWidgets.QSpacerItem(
+            40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum
+        )
         self.horizontalLayout.addItem(spacerItem)
         self.gridLayout.addLayout(self.horizontalLayout, 3, 0, 1, 1)
         self.uLayerDescription = QtWidgets.QLabel(self.groupBox_2)
@@ -103,10 +112,14 @@ class Ui_ContourDialog(object):
         self.uLayerContours = QtWidgets.QRadioButton(self.groupBox)
         self.uLayerContours.setObjectName("uLayerContours")
         self.horizontalLayout_7.addWidget(self.uLayerContours)
-        spacerItem1 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+        spacerItem1 = QtWidgets.QSpacerItem(
+            40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum
+        )
         self.horizontalLayout_7.addItem(spacerItem1)
         self.gridLayout_2.addLayout(self.horizontalLayout_7, 0, 0, 1, 3)
-        spacerItem2 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+        spacerItem2 = QtWidgets.QSpacerItem(
+            20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding
+        )
         self.gridLayout_2.addItem(spacerItem2, 10, 1, 1, 1)
         self.label_5 = QtWidgets.QLabel(self.groupBox)
         self.label_5.setObjectName("label_5")
@@ -115,7 +128,9 @@ class Ui_ContourDialog(object):
         self.label.setObjectName("label")
         self.gridLayout_2.addWidget(self.label, 3, 0, 1, 1)
         self.uNContour = QtWidgets.QSpinBox(self.groupBox)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.uNContour.sizePolicy().hasHeightForWidth())
@@ -129,7 +144,9 @@ class Ui_ContourDialog(object):
         self.label_10.setObjectName("label_10")
         self.gridLayout_2.addWidget(self.label_10, 8, 0, 1, 1)
         self.uExtend = QtWidgets.QComboBox(self.groupBox)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.uExtend.sizePolicy().hasHeightForWidth())
@@ -143,12 +160,16 @@ class Ui_ContourDialog(object):
         self.uSetMaximum.setObjectName("uSetMaximum")
         self.horizontalLayout_6.addWidget(self.uSetMaximum)
         self.uMaxContour = QtWidgets.QDoubleSpinBox(self.groupBox)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.uMaxContour.sizePolicy().hasHeightForWidth())
         self.uMaxContour.setSizePolicy(sizePolicy)
-        self.uMaxContour.setLocale(QtCore.QLocale(QtCore.QLocale.C, QtCore.QLocale.AnyCountry))
+        self.uMaxContour.setLocale(
+            QtCore.QLocale(QtCore.QLocale.C, QtCore.QLocale.AnyCountry)
+        )
         self.uMaxContour.setDecimals(4)
         self.uMaxContour.setMinimum(-999999999.0)
         self.uMaxContour.setMaximum(999999999.0)
@@ -159,7 +180,9 @@ class Ui_ContourDialog(object):
         self.label_7.setObjectName("label_7")
         self.gridLayout_2.addWidget(self.label_7, 1, 0, 1, 1)
         self.uMethod = QtWidgets.QComboBox(self.groupBox)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.uMethod.sizePolicy().hasHeightForWidth())
@@ -174,12 +197,16 @@ class Ui_ContourDialog(object):
         self.uSetMinimum.setObjectName("uSetMinimum")
         self.horizontalLayout_5.addWidget(self.uSetMinimum)
         self.uMinContour = QtWidgets.QDoubleSpinBox(self.groupBox)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.uMinContour.sizePolicy().hasHeightForWidth())
         self.uMinContour.setSizePolicy(sizePolicy)
-        self.uMinContour.setLocale(QtCore.QLocale(QtCore.QLocale.C, QtCore.QLocale.AnyCountry))
+        self.uMinContour.setLocale(
+            QtCore.QLocale(QtCore.QLocale.C, QtCore.QLocale.AnyCountry)
+        )
         self.uMinContour.setDecimals(4)
         self.uMinContour.setMinimum(-999999999.0)
         self.uMinContour.setMaximum(999999999.0)
@@ -190,12 +217,18 @@ class Ui_ContourDialog(object):
         self.label_6.setObjectName("label_6")
         self.gridLayout_2.addWidget(self.label_6, 7, 0, 1, 1)
         self.uContourInterval = QtWidgets.QDoubleSpinBox(self.groupBox)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
-        sizePolicy.setHeightForWidth(self.uContourInterval.sizePolicy().hasHeightForWidth())
+        sizePolicy.setHeightForWidth(
+            self.uContourInterval.sizePolicy().hasHeightForWidth()
+        )
         self.uContourInterval.setSizePolicy(sizePolicy)
-        self.uContourInterval.setLocale(QtCore.QLocale(QtCore.QLocale.C, QtCore.QLocale.AnyCountry))
+        self.uContourInterval.setLocale(
+            QtCore.QLocale(QtCore.QLocale.C, QtCore.QLocale.AnyCountry)
+        )
         self.uContourInterval.setDecimals(4)
         self.uContourInterval.setMinimum(-999999999.0)
         self.uContourInterval.setMaximum(999999999.0)
@@ -205,12 +238,16 @@ class Ui_ContourDialog(object):
         self.label_15.setObjectName("label_15")
         self.gridLayout_2.addWidget(self.label_15, 2, 0, 1, 1)
         self.uLevelsList = QtWidgets.QListWidget(self.groupBox)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Preferred)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Preferred
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.uLevelsList.sizePolicy().hasHeightForWidth())
         self.uLevelsList.setSizePolicy(sizePolicy)
-        self.uLevelsList.setLocale(QtCore.QLocale(QtCore.QLocale.C, QtCore.QLocale.AnyCountry))
+        self.uLevelsList.setLocale(
+            QtCore.QLocale(QtCore.QLocale.C, QtCore.QLocale.AnyCountry)
+        )
         self.uLevelsList.setObjectName("uLevelsList")
         self.gridLayout_2.addWidget(self.uLevelsList, 1, 2, 10, 1)
         self.verticalLayout_2.addWidget(self.groupBox)
@@ -231,7 +268,9 @@ class Ui_ContourDialog(object):
         self.horizontalLayout_2.setContentsMargins(0, 0, -1, -1)
         self.horizontalLayout_2.setObjectName("horizontalLayout_2")
         self.uPrecision = QtWidgets.QSpinBox(self.groupBox_3)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.uPrecision.sizePolicy().hasHeightForWidth())
@@ -254,9 +293,13 @@ class Ui_ContourDialog(object):
         self.uLabelUnits = QtWidgets.QLineEdit(self.groupBox_3)
         self.uLabelUnits.setObjectName("uLabelUnits")
         self.horizontalLayout_2.addWidget(self.uLabelUnits)
-        spacerItem3 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+        spacerItem3 = QtWidgets.QSpacerItem(
+            40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum
+        )
         self.horizontalLayout_2.addItem(spacerItem3)
-        self.formLayout.setLayout(1, QtWidgets.QFormLayout.FieldRole, self.horizontalLayout_2)
+        self.formLayout.setLayout(
+            1, QtWidgets.QFormLayout.FieldRole, self.horizontalLayout_2
+        )
         self.label_9 = QtWidgets.QLabel(self.groupBox_3)
         self.label_9.setObjectName("label_9")
         self.formLayout.setWidget(1, QtWidgets.QFormLayout.LabelRole, self.label_9)
@@ -273,10 +316,14 @@ class Ui_ContourDialog(object):
         self.uReverseRamp = QtWidgets.QCheckBox(self.groupBox_3)
         self.uReverseRamp.setObjectName("uReverseRamp")
         self.horizontalLayout_4.addWidget(self.uReverseRamp)
-        spacerItem4 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+        spacerItem4 = QtWidgets.QSpacerItem(
+            40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum
+        )
         self.horizontalLayout_4.addItem(spacerItem4)
         self.horizontalLayout_4.setStretch(1, 1)
-        self.formLayout.setLayout(2, QtWidgets.QFormLayout.FieldRole, self.horizontalLayout_4)
+        self.formLayout.setLayout(
+            2, QtWidgets.QFormLayout.FieldRole, self.horizontalLayout_4
+        )
         self.label_13 = QtWidgets.QLabel(self.groupBox_3)
         self.label_13.setObjectName("label_13")
         self.formLayout.setWidget(2, QtWidgets.QFormLayout.LabelRole, self.label_13)
@@ -286,7 +333,9 @@ class Ui_ContourDialog(object):
         self.scrollArea_2.setWidget(self.scrollAreaWidgetContents_2)
         self.verticalLayout.addWidget(self.scrollArea_2)
         self.uMessageBar = QgsMessageBar(ContourDialog)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred
+        )
         sizePolicy.setHorizontalStretch(1)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.uMessageBar.sizePolicy().hasHeightForWidth())
@@ -366,10 +415,14 @@ class Ui_ContourDialog(object):
         self.groupBox_2.setTitle(_translate("ContourDialog", "Input"))
         self.label_3.setText(_translate("ContourDialog", "Point layer"))
         self.label_4.setText(_translate("ContourDialog", "Data value"))
-        self.uSelectedOnly.setText(_translate("ContourDialog", "Use selected points only"))
+        self.uSelectedOnly.setText(
+            _translate("ContourDialog", "Use selected points only")
+        )
         self.label_2.setText(_translate("ContourDialog", "Remove duplicate points"))
         self.label_11.setText(_translate("ContourDialog", "Tolerance"))
-        self.uUseGridLabel.setText(_translate("ContourDialog", "Use grid based contouring"))
+        self.uUseGridLabel.setText(
+            _translate("ContourDialog", "Use grid based contouring")
+        )
         self.groupBox.setTitle(_translate("ContourDialog", "Contouring"))
         self.uLinesContours.setText(_translate("ContourDialog", "contour lines"))
         self.uFilledContours.setText(_translate("ContourDialog", "filled contours"))
@@ -377,7 +430,12 @@ class Ui_ContourDialog(object):
         self.uLayerContours.setText(_translate("ContourDialog", "contour layers"))
         self.label_5.setText(_translate("ContourDialog", "Minimum"))
         self.label.setText(_translate("ContourDialog", "Number"))
-        self.uNContour.setStatusTip(_translate("ContourDialog", "Number of levels between min and max value (from data field)"))
+        self.uNContour.setStatusTip(
+            _translate(
+                "ContourDialog",
+                "Number of levels between min and max value (from data field)",
+            )
+        )
         self.label_10.setText(_translate("ContourDialog", "Extend"))
         self.uSetMaximum.setText(_translate("ContourDialog", "Set"))
         self.label_7.setText(_translate("ContourDialog", "Method"))
@@ -386,7 +444,9 @@ class Ui_ContourDialog(object):
         self.label_15.setText(_translate("ContourDialog", "Interval"))
         self.groupBox_3.setTitle(_translate("ContourDialog", "Output"))
         self.label_8.setText(_translate("ContourDialog", "Layer name"))
-        self.uPrecision.setStatusTip(_translate("ContourDialog", "Number of decimal places shown in labels"))
+        self.uPrecision.setStatusTip(
+            _translate("ContourDialog", "Number of decimal places shown in labels")
+        )
         self.label_14.setText(_translate("ContourDialog", "Trim zeros"))
         self.label_12.setText(_translate("ContourDialog", "Units"))
         self.label_9.setText(_translate("ContourDialog", "Label precision"))
@@ -395,6 +455,7 @@ class Ui_ContourDialog(object):
         self.uHelpButton.setText(_translate("ContourDialog", "Help"))
         self.uAddButton.setText(_translate("ContourDialog", "Add"))
         self.uCloseButton.setText(_translate("ContourDialog", "Close"))
+
 
 from qgis.gui import QgsColorRampButton
 from qgis.gui import QgsFieldExpressionWidget

--- a/contour/ContourGenerator.py
+++ b/contour/ContourGenerator.py
@@ -10,6 +10,7 @@ from .ContourMethod import ContourMethodError
 qgis_qhull_fails = platform.platform().startswith("Linux")
 
 from qgis.core import (
+    Qgis,
     QgsExpression,
     QgsExpressionContext,
     QgsFeature,
@@ -70,20 +71,25 @@ class ContourExtendOption:
         neither: tr("Don't fill below or above maximum contour"),
     }
 
+    @staticmethod
     def options():
         return ContourExtendOption._options
 
+    @staticmethod
     def valid(option):
         return option in ContourExtendOption._options
 
+    @staticmethod
     def description(option):
         return ContourExtendOption._description.get(
             option, tr("Invalid contour option {0}").format(option)
         )
 
+    @staticmethod
     def extendBelow(option):
         return option in ContourExtendOption._below
 
+    @staticmethod
     def extendAbove(option):
         return option in ContourExtendOption._above
 
@@ -107,17 +113,21 @@ class ContourType:
         layer: QgsWkbTypes.MultiPolygon,
     }
 
+    @staticmethod
     def types():
         return ContourType._types
 
+    @staticmethod
     def valid(type):
         return type in ContourType._types
 
+    @staticmethod
     def description(type):
         return ContourType._description.get(
             type, tr("Invalid contour type {0}").format(type)
         )
 
+    @staticmethod
     def wkbtype(type):
         return ContourType._wkbtype.get(type)
 
@@ -520,6 +530,34 @@ class ContourGenerator(QObject):
     def _levelLabel(self, level):
         return self.formatLevel(level) + self._labelUnits
 
+    def _contourPathsFromContourSet(self, cs):
+        """
+        Routine to extract paths from a matplotlib ContourSet.  This was
+        modified at matplotlib version 3.8.0 - this routine handles returns
+        an array of paths for each level for either before or after this change.
+        After 3.8.0 the array will contain just one path for each level.
+
+        (https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.8.0.html)
+        Prior to this release, ContourSet (the object returned by contour) was a custom object
+        holding multiple Collections (and not an Artist) -- one collection per level, each
+        connected component of that level's contour being an entry in the corresponding collection.
+
+        ContourSet is now instead a plain Collection (and thus an Artist). The collection contains
+        a single path per contour level; this path may be non-continuous in case there are multiple
+        connected components.
+        """
+
+        from matplotlib.collections import Collection
+
+        # After 3.8.0 the ContourSet is just a collection
+        if isinstance(cs, Collection):
+            return [[p] for p in cs.get_paths()]
+
+        paths = []
+        for collection in cs.collections:
+            paths.append(collection.get_paths())
+        return paths
+
     def lineContourFeatures(self):
         x, y, z = self.data()
         levels = self.levels()
@@ -537,13 +575,13 @@ class ContourGenerator(QObject):
         fields = self.fields()
         zfield = self.zFieldName()
         dx, dy = self._origin
-        for i, line in enumerate(cs.collections):
+        for i, layerLines in enumerate(cs.allsegs):
             level = float(cs.levels[i])
             glines = []
             try:
-                for path in line.get_paths():
-                    if len(path.vertices) > 1:
-                        points = [QgsPointXY(x, y) for x, y in path.vertices]
+                for line in layerLines:
+                    points = [QgsPointXY(x, y) for x, y in line]
+                    if len(points) > 1:
                         glines.append(points)
                 geom = QgsGeometry.fromMultiPolylineXY(glines)
                 geom.translate(dx, dy)
@@ -573,27 +611,35 @@ class ContourGenerator(QObject):
             lmin = ""
         return lmin + op + lmax + self._labelUnits
 
-    def buildQgsMultipolygon(self, polygon):
+    def buildQgsPolygons(self, paths):
         """
-        Construct QgsMultiPolygon from matplotlib version
+        Construct QgsPolygon geometries from matplotlib version
         """
         mpoly = []
         invalid = 0
-        for path in polygon.get_paths():
+        notpoly = {}
+        for path in paths:
             path.should_simplify = False
             poly = path.to_polygons()
             if len(poly) < 1:
                 continue
             if len(poly[0]) < 3:
-                # Have had one vertix polygon from matplotlib!
+                # Have had one vertex polygon from matplotlib!
                 continue
-            polypts = [[QgsPointXY(x, y) for x, y in p] for p in poly if len(p) > 3]
-            mpoly.append(polypts)
-        geom = None
-        if len(mpoly) > 0:
-            geom = QgsGeometry.fromMultiPolygonXY(mpoly)
-            geom = geom.makeValid()
-        return geom
+            polypts = [[QgsPointXY(x, y) for x, y in p] for p in poly if len(p) >= 3]
+            pgn = QgsGeometry.fromPolygonXY(polypts)
+            pgn = pgn.makeValid()
+            if pgn.type() == Qgis.GeometryType.Polygon:
+                mpoly.append(pgn)
+            else:
+                ptype = pgn.type().name
+                if ptype not in notpoly:
+                    notpoly[ptype] = 0
+                notpoly[ptype] += 1
+        if notpoly:
+            warning = f"Ignoring non-polygon features: {' '.join((f'{k}:{v}' for k,v in notpoly.items()))}"
+            self._feedback.pushInfo(tr(warning))
+        return mpoly
 
     def filledContourFeatures(self):
         levels = self.levels()
@@ -608,6 +654,8 @@ class ContourGenerator(QObject):
                 cs = tricontourf(trig, z, levels, extend=extend)
         except:
             raise ContourGenerationError.fromException(sys.exc_info())
+
+        contourPaths = self._contourPathsFromContourSet(cs)
 
         levels = [float(l) for l in cs.levels]
         if ContourExtendOption.extendBelow(extend):
@@ -632,30 +680,29 @@ class ContourGenerator(QObject):
         zminfield = zfieldname + "_min"
         zmaxfield = zfieldname + "_max"
 
-        for i, polygon in enumerate(cs.collections):
+        for i, paths in enumerate(contourPaths):
             level_min = levels[i]
             level_max = levels[i + 1]
             label = self._rangeLabel(level_min, level_max)
             try:
                 try:
-                    geom = self.buildQgsMultipolygon(polygon)
-                    if geom is None:
+                    mpoly = self.buildQgsPolygons(paths)
+                    if len(mpoly) == 0:
                         continue
-                    geom.translate(dx, dy)
                 except Exception as ex:
                     ninvalid += 1
                     continue
-                feat = QgsFeature(fields)
-                feat.setGeometry(geom)
-                feat["index"] = i
-                feat[zminfield] = float(level_min)
-                feat[zmaxfield] = float(level_max)
-                feat["label"] = label
-                yield feat
+                for geom in mpoly:
+                    geom.translate(dx, dy)
+                    feat = QgsFeature(fields)
+                    feat.setGeometry(geom)
+                    feat["index"] = i
+                    feat[zminfield] = float(level_min)
+                    feat[zmaxfield] = float(level_max)
+                    feat["label"] = label
+                    yield feat
             except Exception as ex:
-                raise
-                self._feedback.reportError(sys.exc_info()[1])
-
+                self._feedback.reportError(str(ex))
         if ninvalid > 0:
             self._feedback.pushInfo(
                 tr("{0} invalid contour geometries discarded").format(ninvalid)
@@ -671,6 +718,7 @@ class ContourGenerator(QObject):
                 trig, gz = self.trigContourData()
         except:
             raise ContourGenerationError.fromException(sys.exc_info())
+            contourPaths = self._contourPathsFromContourSet(cs)
 
         fields = self.fields()
         ninvalid = 0
@@ -694,24 +742,26 @@ class ContourGenerator(QObject):
                     )
             except:
                 raise ContourGenerationError.fromException(sys.exc_info())
-            if len(cs.collections) < 1:
+            contourPaths = self._contourPathsFromContourSet(cs)
+            if len(contourPaths) < 1:
                 continue
-            polygon = cs.collections[0]
+            polygon = contourPaths[0]
             try:
                 try:
-                    geom = self.buildQgsMultipolygon(polygon)
-                    if geom is None:
+                    mpoly = self.buildQgsPolygons(polygon)
+                    if len(mpoly) == 0:
                         continue
-                    geom.translate(dx, dy)
                 except Exception as ex:
                     ninvalid += 1
                     continue
-                feat = QgsFeature(fields)
-                feat.setGeometry(geom)
-                feat["index"] = i
-                feat[zfield] = float(level)
-                feat["label"] = self._levelLabel(level)
-                yield feat
+                for geom in mpoly:
+                    geom.translate(dx, dy)
+                    feat = QgsFeature(fields)
+                    feat.setGeometry(geom)
+                    feat["index"] = i
+                    feat[zfield] = float(level)
+                    feat["label"] = self._levelLabel(level)
+                    yield feat
             except Exception as ex:
                 self._feedback.reportError(ex.message)
 

--- a/contour/ContourGenerator.py
+++ b/contour/ContourGenerator.py
@@ -1,4 +1,3 @@
-
 import platform
 import re
 import sys
@@ -8,7 +7,7 @@ from . import ContourUtils
 from . import ContourMethod
 from .ContourMethod import ContourMethodError
 
-qgis_qhull_fails=platform.platform().startswith('Linux')
+qgis_qhull_fails = platform.platform().startswith("Linux")
 
 from qgis.core import (
     QgsExpression,
@@ -19,125 +18,136 @@ from qgis.core import (
     QgsGeometry,
     QgsPointXY,
     QgsFields,
-    QgsWkbTypes
-    )
-from PyQt5.QtCore import (
-    QObject,
-    QVariant,
-    QCoreApplication
-    )
+    QgsWkbTypes,
+)
+from PyQt5.QtCore import QObject, QVariant, QCoreApplication
 
-_mplAvailable=False
+_mplAvailable = False
 try:
     import numpy as np
     from matplotlib.pyplot import contour, contourf, tricontour, tricontourf
     from matplotlib.tri import Triangulation, TriAnalyzer
-    _mplAvailable=True
+
+    _mplAvailable = True
 except ImportError:
-    _mplAvailable=False
+    _mplAvailable = False
     pass
 
-def tr(string):
-    return QCoreApplication.translate('Processing', string)
 
-class ContourError( RuntimeError ):
+def tr(string):
+    return QCoreApplication.translate("Processing", string)
+
+
+class ContourError(RuntimeError):
 
     def message(self):
         return self.args[0] if len(self.args) > 0 else "Exception"
 
-class ContourGenerationError( ContourError ):
+
+class ContourGenerationError(ContourError):
 
     @staticmethod
-    def fromException( excinfo ):
-        message=traceback.format_exception_only(excinfo[0],excinfo[1])
+    def fromException(excinfo):
+        message = traceback.format_exception_only(excinfo[0], excinfo[1])
         return ContourGenerationError(message)
+
 
 class ContourExtendOption:
 
-    both='both'
-    below='min'
-    above='max'
-    neither='neither'
+    both = "both"
+    below = "min"
+    above = "max"
+    neither = "neither"
 
-    _options=[both,below,above,neither]
-    _above=[both,above]
-    _below=[both,below]
+    _options = [both, below, above, neither]
+    _above = [both, above]
+    _below = [both, below]
 
-    _description={
-        both: tr('Fill below minimum and above maximum contour'),
-        below: tr('Fill below minimum contour'),
-        above: tr('Fill above maximum contour'),
-        neither: tr('Don\'t fill below or above maximum contour')
-        }
+    _description = {
+        both: tr("Fill below minimum and above maximum contour"),
+        below: tr("Fill below minimum contour"),
+        above: tr("Fill above maximum contour"),
+        neither: tr("Don't fill below or above maximum contour"),
+    }
 
     def options():
         return ContourExtendOption._options
 
-    def valid( option ):
+    def valid(option):
         return option in ContourExtendOption._options
 
-    def description( option ):
-        return ContourExtendOption._description.get(option,tr('Invalid contour option {0}').format(option))
+    def description(option):
+        return ContourExtendOption._description.get(
+            option, tr("Invalid contour option {0}").format(option)
+        )
 
-    def extendBelow( option ):
+    def extendBelow(option):
         return option in ContourExtendOption._below
 
-    def extendAbove( option ):
+    def extendAbove(option):
         return option in ContourExtendOption._above
 
+
 class ContourType:
-    line='line'
-    filled='filled'
-    layer='layer'
+    line = "line"
+    filled = "filled"
+    layer = "layer"
 
-    _types=[line, filled, layer]
+    _types = [line, filled, layer]
 
-    _description={
-        line: tr('Contour lines'),
-        filled: tr('Filled contour polygons'),
-        layer: tr('Layer contour polygons')
-        }
+    _description = {
+        line: tr("Contour lines"),
+        filled: tr("Filled contour polygons"),
+        layer: tr("Layer contour polygons"),
+    }
 
-    _wkbtype={
+    _wkbtype = {
         line: QgsWkbTypes.MultiLineString,
         filled: QgsWkbTypes.MultiPolygon,
         layer: QgsWkbTypes.MultiPolygon,
-        }
+    }
 
     def types():
         return ContourType._types
 
-    def valid( type ):
+    def valid(type):
         return type in ContourType._types
 
-    def description( type ):
-        return ContourType._description.get(type,tr('Invalid contour type {0}').format(type))
+    def description(type):
+        return ContourType._description.get(
+            type, tr("Invalid contour type {0}").format(type)
+        )
 
-    def wkbtype( type ):
+    def wkbtype(type):
         return ContourType._wkbtype.get(type)
+
 
 class _DummyFeedback:
 
-    def isCanceled( self ):
+    def isCanceled(self):
         return False
 
-    def setProgress( self, percent ):
+    def setProgress(self, percent):
         pass
 
-    def pushInfo( self, info ):
+    def pushInfo(self, info):
         pass
 
-    def reportError( self, message, fatal=False ):
-        raise ContourError( message )
-
-class ContourGenerator( QObject ):
-
-    MaxContours=100
-    translateExtend=lambda self, x: {'none':'neither','below':'min','above':'max'}.get(x.lower(),x.lower())
+    def reportError(self, message, fatal=False):
+        raise ContourError(message)
 
 
-    def __init__( self, source=None, zField=None, feedback=None ):
-        '''
+class ContourGenerator(QObject):
+
+    MaxContours = 100
+    translateExtend = lambda self, x: {
+        "none": "neither",
+        "below": "min",
+        "above": "max",
+    }.get(x.lower(), x.lower())
+
+    def __init__(self, source=None, zField=None, feedback=None):
+        """
         Initiallize the contour generator with source and field expression.
         The initiallization will attempt to load the data.
 
@@ -145,19 +155,19 @@ class ContourGenerator( QObject ):
             fieldback.isCanceled()
             fieldback.setProgress(percent_progress)
             ...
-        '''
+        """
         QObject.__init__(self)
         if not _mplAvailable:
             raise ContourError(tr("python matplotlib not available"))
         self._x = None
         self._y = None
         self._z = None
-        self._origin = [0,0] # NOTE: calculate in data()
-        self._source=None
-        self._sourceFids=None
+        self._origin = [0, 0]  # NOTE: calculate in data()
+        self._source = None
+        self._sourceFids = None
         self._zField = None
         self._zFieldName = None
-        self._discardTolerance=0
+        self._discardTolerance = 0
         self._dataLoaded = False
         self._gridTested = False
         self._gridShape = None
@@ -171,91 +181,93 @@ class ContourGenerator( QObject ):
         self._labelNdp = -1
         self._defaultLabelNdp = None
         self._labelTrimZeros = False
-        self._labelUnits = ''
+        self._labelUnits = ""
         self._feedback = feedback or _DummyFeedback()
-        self.setDataSource( source, zField )
+        self.setDataSource(source, zField)
 
-    def _dataDef( self ):
+    def _dataDef(self):
         return (
-            None if self._source is None else 'source', # self._source.id(),
+            None if self._source is None else "source",  # self._source.id(),
             self._zField,
-            self._discardTolerance
-            )   
+            self._discardTolerance,
+        )
 
     # Functions to support null feedback
-    def isCanceled( self ):
+    def isCanceled(self):
         return None
 
-    def setDataSource( self, source, zField=None, sourceFids=None, zFieldName=None ):
+    def setDataSource(self, source, zField=None, sourceFids=None, zFieldName=None):
         if self._source != source or self._sourceFids != sourceFids:
             self.setReloadData()
-        self._source=source
-        self._sourceFids=sourceFids
+        self._source = source
+        self._sourceFids = sourceFids
         if zField is not None:
-            self.setZField(zField,zFieldName)
+            self.setZField(zField, zFieldName)
 
-    def setDuplicatePointTolerance( self, discardTolerance ):
+    def setDuplicatePointTolerance(self, discardTolerance):
         if self._discardTolerance != discardTolerance:
-            self._discardTolerance=discardTolerance
+            self._discardTolerance = discardTolerance
             self.setReloadData()
 
-    def setZField( self, zField, zFieldName=None ):
+    def setZField(self, zField, zFieldName=None):
         if self._zField != zField:
-            self._zField=zField
-            self._zFieldName=zFieldName
+            self._zField = zField
+            self._zFieldName = zFieldName
             self.setReloadData()
 
-    def setUseGrid( self, usegrid ):
-        self._useGrid=usegrid
+    def setUseGrid(self, usegrid):
+        self._useGrid = usegrid
 
-    def setContourLevels( self, levels ):
-        self.setContourMethod('manual',{'levels':levels})
+    def setContourLevels(self, levels):
+        self.setContourMethod("manual", {"levels": levels})
 
-    def setContourMethod( self, method, params ):
-        self._contourMethod=method
-        self._contourMethodParams=params
-        self._levels=None
+    def setContourMethod(self, method, params):
+        self._contourMethod = method
+        self._contourMethodParams = params
+        self._levels = None
 
-    def setContourType( self, contourType ):
-        contourType=contourType.lower()
+    def setContourType(self, contourType):
+        contourType = contourType.lower()
         if not ContourType.valid(contourType):
             raise ContourError(tr("Invalid contour type {0}").format(contourType))
-        self._contourType=contourType
+        self._contourType = contourType
 
-    def setContourExtendOption( self, extend ):
-        extend=extend.lower()
+    def setContourExtendOption(self, extend):
+        extend = extend.lower()
         if not ContourExtendOption.valid(extend):
-            raise ContourError(tr("Invalid filled contour extend option {0}").format(extend))
-        self._extendFilled=extend
+            raise ContourError(
+                tr("Invalid filled contour extend option {0}").format(extend)
+            )
+        self._extendFilled = extend
 
-    def setLabelFormat( self, ndp, trim=False, units='' ):
+    def setLabelFormat(self, ndp, trim=False, units=""):
         self._labelNdp = ndp
         self._labelTrimZeros = trim
         self._labelUnits = units
 
-    def setReloadData( self ):
-        self._dataLoaded=False
-        self._gridTested=False
-        self._levels=None
+    def setReloadData(self):
+        self._dataLoaded = False
+        self._gridTested = False
+        self._levels = None
 
-    def data( self ):
+    def data(self):
         if self._dataLoaded:
             return self._x, self._y, self._z
-        self._dataLoaded=True
+        self._dataLoaded = True
         self._x = None
         self._y = None
         self._z = None
-        self._gridShape=None
-        self._gridTested=False
-        self._dataLoaded=True
+        self._gridShape = None
+        self._gridTested = False
+        self._dataLoaded = True
 
-        source=self._source
-        zField=self._zField
-        if source is None or zField is None or zField == '':
+        source = self._source
+        zField = self._zField
+        if source is None or zField is None or zField == "":
             return self._x, self._y, self._z
 
-        discardTolerance=self._discardTolerance
-        feedback=self._feedback
+        discardTolerance = self._discardTolerance
+        feedback = self._feedback
 
         total = source.featureCount()
         percent = 100.0 / total if total > 0 else 0
@@ -266,38 +278,41 @@ class ContourGenerator( QObject ):
         z = list()
         try:
             if source.fields().lookupField(zField) >= 0:
-                zField='"'+zField.replace('"','""')+'"'
-            expression=QgsExpression(zField)
+                zField = '"' + zField.replace('"', '""') + '"'
+            expression = QgsExpression(zField)
             if expression.hasParserError():
-                raise ContourError(tr("Cannot parse")+" "+zField)
-            fields=source.fields()
-            context=QgsExpressionContext()
+                raise ContourError(tr("Cannot parse") + " " + zField)
+            fields = source.fields()
+            context = QgsExpressionContext()
             context.setFields(fields)
             if not expression.prepare(context):
-                raise ContourError(tr("Cannot evaluate value")+ " "+zField)
+                raise ContourError(tr("Cannot evaluate value") + " " + zField)
             request = QgsFeatureRequest()
-            request.setSubsetOfAttributes( expression.referencedColumns(),fields)
+            request.setSubsetOfAttributes(expression.referencedColumns(), fields)
             if self._sourceFids is not None:
                 request.setFilterFids(self._sourceFids)
-            for current,feat in enumerate(source.getFeatures( request )):
+            for current, feat in enumerate(source.getFeatures(request)):
                 try:
                     if feedback.isCanceled():
-                        raise ContourError('Cancelled by user')
+                        raise ContourError("Cancelled by user")
                     feedback.setProgress(int(current * percent))
                     context.setFeature(feat)
-                    zval=expression.evaluate(context)
-                    if zval is None or (isinstance(zval,QVariant) and zval.isNull()):
+                    zval = expression.evaluate(context)
+                    if zval is None or (isinstance(zval, QVariant) and zval.isNull()):
                         continue
                     try:
-                        zval=float(zval)
+                        zval = float(zval)
                     except ValueError:
-                        raise ContourError(tr("Z value {0} is not number")
-                                                   .format(zval))
+                        raise ContourError(tr("Z value {0} is not number").format(zval))
                     if zval is not None:
                         fgeom = feat.geometry()
                         if QgsWkbTypes.flatType(fgeom.wkbType()) != QgsWkbTypes.Point:
-                            raise ContourError(tr("Invalid geometry type for contouring - must be point geometry"))
-                        geom=fgeom.asPoint()
+                            raise ContourError(
+                                tr(
+                                    "Invalid geometry type for contouring - must be point geometry"
+                                )
+                            )
+                        geom = fgeom.asPoint()
                         x.append(geom.x())
                         y.append(geom.y())
                         z.append(zval)
@@ -305,34 +320,38 @@ class ContourGenerator( QObject ):
                     raise
                 count = count + 1
 
-            npt=len(x)
+            npt = len(x)
             if npt > 0:
-                x=np.array(x)
-                y=np.array(y)
-                z=np.array(z)
+                x = np.array(x)
+                y = np.array(y)
+                z = np.array(z)
                 if discardTolerance > 0:
-                    index=ContourUtils.discardDuplicatePoints(
-                        x,y,discardTolerance,self.crs().isGeographic())
-                    npt1=len(index)
+                    index = ContourUtils.discardDuplicatePoints(
+                        x, y, discardTolerance, self.crs().isGeographic()
+                    )
+                    npt1 = len(index)
                     if npt1 < npt:
-                        x=x[index]
-                        y=y[index]
-                        z=z[index]
-                        feedback.pushInfo(tr("{0} near duplicate points discarded - tolerance {1}")
-                                          .format(npt-npt1,discardTolerance))
+                        x = x[index]
+                        y = y[index]
+                        z = z[index]
+                        feedback.pushInfo(
+                            tr(
+                                "{0} near duplicate points discarded - tolerance {1}"
+                            ).format(npt - npt1, discardTolerance)
+                        )
         except ContourError as ce:
             feedback.reportError(ce.message())
             feedback.setProgress(0)
-            return self._x,self._y,self._z
+            return self._x, self._y, self._z
         finally:
             feedback.setProgress(0)
 
         if len(x) < 3:
             feedback.reportError(tr("Too few points to contour"))
             return self._x, self._y, self._z
-        self._x=x
-        self._y=y
-        self._z=z
+        self._x = x
+        self._y = y
+        self._z = z
         return self._x, self._y, self._z
 
     def isGridded(self):
@@ -340,66 +359,68 @@ class ContourGenerator( QObject ):
         Check if points data are on a regular grid
         """
         if not self._gridTested:
-            x,y,z=self.data()
-            self._gridShape,self._gridOrder=DataGridder(x,y).calcGrid()
-            self._gridTested=True
+            x, y, z = self.data()
+            self._gridShape, self._gridOrder = DataGridder(x, y).calcGrid()
+            self._gridTested = True
         return self._gridShape is not None
 
     def gridShape(self):
         return self._gridShape if self.isGridded() else None
 
-    def levels( self ):
+    def levels(self):
         if self._levels is None:
-            x,y,z = self.data()
+            x, y, z = self.data()
             if z is None:
                 raise ContourError(tr("Contour data not defined"))
-            method=self._contourMethod
-            params=self._contourMethodParams
+            method = self._contourMethod
+            params = self._contourMethodParams
             if method is None:
                 raise ContourError(tr("Contouring method not defined"))
-            self._levels=ContourMethod.calculateLevels(z,method,**params)
+            self._levels = ContourMethod.calculateLevels(z, method, **params)
             self._defaultLabelNdp = None
         return self._levels
 
-    def crs( self ):
+    def crs(self):
         return self._source.sourceCrs()
 
-    def wkbtype( self ):
+    def wkbtype(self):
         return ContourType.wkbtype(self._contourType)
 
-    def zFieldName( self ):
-        zfield=self._zFieldName or self._zField
+    def zFieldName(self):
+        zfield = self._zFieldName or self._zField
         if zfield is None:
-            zfield='none'
-        elif re.search(r'[\(\)]',zfield):
-            zfield='expression'
-        elif re.match(r'^\"([^\"]|\"\")+\"$',zfield):
-            zfield=zfield[1:-1].replace('""','"')
-        zfield=re.sub(r'\W+','_',zfield)
-        if re.match(r'^\d',zfield):
-            zfield='_'+zfield
+            zfield = "none"
+        elif re.search(r"[\(\)]", zfield):
+            zfield = "expression"
+        elif re.match(r"^\"([^\"]|\"\")+\"$", zfield):
+            zfield = zfield[1:-1].replace('""', '"')
+        zfield = re.sub(r"\W+", "_", zfield)
+        if re.match(r"^\d", zfield):
+            zfield = "_" + zfield
         return zfield
 
-    def fields( self ):
-        zFieldName=self.zFieldName()
+    def fields(self):
+        zFieldName = self.zFieldName()
         if self._contourType == ContourType.filled:
-            fielddef= [('index',int),
-                       (zFieldName+"_min",float),
-                       (zFieldName+"_max",float),
-                       ('label',str)
-                      ]
+            fielddef = [
+                ("index", int),
+                (zFieldName + "_min", float),
+                (zFieldName + "_max", float),
+                ("label", str),
+            ]
         else:
-            fielddef= [('index',int),
-                      (zFieldName,float),
-                      ('label',str)
-                      ]
+            fielddef = [("index", int), (zFieldName, float), ("label", str)]
         fields = QgsFields()
         for name, ftype in fielddef:
             fields.append(
-                QgsField(name,QVariant.Int,'Int') if ftype == int else
-                QgsField(name,QVariant.Double,'Double') if ftype == float else
-                QgsField(name,QVariant.String,'String')
+                QgsField(name, QVariant.Int, "Int")
+                if ftype == int
+                else (
+                    QgsField(name, QVariant.Double, "Double")
+                    if ftype == float
+                    else QgsField(name, QVariant.String, "String")
                 )
+            )
         return fields
 
     def contourFeatures(self):
@@ -413,151 +434,151 @@ class ContourGenerator( QObject ):
             return []
 
     def gridContourData(self):
-        gx,gy,gz=self.data()
-        order=self._gridOrder
-        shape=self._gridShape
+        gx, gy, gz = self.data()
+        order = self._gridOrder
+        shape = self._gridShape
         if order is not None:
-            gx=gx[order]
-            gy=gy[order]
-            gz=gz[order]
-        gx=gx.reshape(shape)
-        gy=gy.reshape(shape)
-        gz=gz.reshape(shape)
-        self._feedback.pushInfo("Contouring {0} by {1} grid"
-            .format(shape[0],shape[1]))
+            gx = gx[order]
+            gy = gy[order]
+            gz = gz[order]
+        gx = gx.reshape(shape)
+        gy = gy.reshape(shape)
+        gz = gz.reshape(shape)
+        self._feedback.pushInfo("Contouring {0} by {1} grid".format(shape[0], shape[1]))
         return gx, gy, gz
 
-    def _buildtrig_workaround( self, x, y ):
-        '''
+    def _buildtrig_workaround(self, x, y):
+        """
         Workaround implemented as qhull fails when called from
-        within QGIS python in ubuntu 17.10, QGIS 3.1 :-( 
-        ''' 
+        within QGIS python in ubuntu 17.10, QGIS 3.1 :-(
+        """
         import os
         import sys
         import subprocess
         import tempfile
-        tfh,tfname=tempfile.mkstemp('.npy','tmp_contour_generator')
-        tfh2,tfname2=tempfile.mkstemp('.npy','tmp_contour_generator')
+
+        tfh, tfname = tempfile.mkstemp(".npy", "tmp_contour_generator")
+        tfh2, tfname2 = tempfile.mkstemp(".npy", "tmp_contour_generator")
         os.close(tfh)
         os.close(tfh2)
-        trig=None
+        trig = None
         try:
-            np.save(tfname,np.vstack((x,y)))
-            pydir=os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
-            pyscript=os.path.join(pydir,'buildtrig_qhull_workaround.py')
-            python=sys.executable
-            result=subprocess.call([python,pyscript,tfname,tfname2])
-            triangles=np.load(tfname2)
-            trig=Triangulation(x,y,triangles)
+            np.save(tfname, np.vstack((x, y)))
+            pydir = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
+            pyscript = os.path.join(pydir, "buildtrig_qhull_workaround.py")
+            python = sys.executable
+            result = subprocess.call([python, pyscript, tfname, tfname2])
+            triangles = np.load(tfname2)
+            trig = Triangulation(x, y, triangles)
         finally:
             os.remove(tfname)
             os.remove(tfname2)
         return trig
 
-    def buildTriangulation( self, x, y ):
-        trig=None
+    def buildTriangulation(self, x, y):
+        trig = None
         if qgis_qhull_fails:
-            trig=self._buildtrig_workaround(x,y)
+            trig = self._buildtrig_workaround(x, y)
         else:
-            trig=Triangulation(x,y)
-        analyzer=TriAnalyzer(trig)
-        mask=analyzer.get_flat_tri_mask()
+            trig = Triangulation(x, y)
+        analyzer = TriAnalyzer(trig)
+        mask = analyzer.get_flat_tri_mask()
         trig.set_mask(mask)
         return trig
 
     def trigContourData(self):
-        x,y,z=self.data()
-        self._feedback.pushInfo("Triangulating {0} points"
-            .format(len(x)))
-        trig=self.buildTriangulation(x,y)
-        self._feedback.pushInfo("Contouring {0} triangles"
-            .format(trig.triangles.shape[0]))
-        return trig,z
+        x, y, z = self.data()
+        self._feedback.pushInfo("Triangulating {0} points".format(len(x)))
+        trig = self.buildTriangulation(x, y)
+        self._feedback.pushInfo(
+            "Contouring {0} triangles".format(trig.triangles.shape[0])
+        )
+        return trig, z
         return polygons
 
-    def calcLabelNdp( self ):
+    def calcLabelNdp(self):
         if self._labelNdp is not None and self._labelNdp > 0:
             return self._labelNdp
         if self._defaultLabelNdp is None:
-            levels=self.levels()
-            ndp=ContourUtils.calcDefaultNdp(levels)
+            levels = self.levels()
+            ndp = ContourUtils.calcDefaultNdp(levels)
             self._defaultLabelNdp = ndp
         return self._defaultLabelNdp
 
-    def formatLevel( self, level ):
-        ndp=self.calcLabelNdp()
+    def formatLevel(self, level):
+        ndp = self.calcLabelNdp()
         if self._labelNdp == 0:
             return str(int(round(level, 0)))
         elif ndp < 0:
             return str(level)
         elif self._labelTrimZeros:
-            level=np.round(level,ndp)
+            level = np.round(level, ndp)
             return str(level)
         else:
-            return "{1:.{0}f}".format(ndp,level)
+            return "{1:.{0}f}".format(ndp, level)
 
-    def _levelLabel(self,level):
-        return self.formatLevel(level)+self._labelUnits
+    def _levelLabel(self, level):
+        return self.formatLevel(level) + self._labelUnits
 
     def lineContourFeatures(self):
-        x,y,z=self.data()
+        x, y, z = self.data()
         levels = self.levels()
-        usegrid=self.isGridded() and self._useGrid
+        usegrid = self.isGridded() and self._useGrid
         try:
             if usegrid:
-                gx,gy,gz=self.gridContourData()
-                cs = contour(gx, gy, gz, levels )
+                gx, gy, gz = self.gridContourData()
+                cs = contour(gx, gy, gz, levels)
             else:
-                trig,z=self.trigContourData()
-                cs = tricontour(trig, z, levels )
+                trig, z = self.trigContourData()
+                cs = tricontour(trig, z, levels)
         except:
             raise ContourGenerationError.fromException(sys.exc_info())
 
         fields = self.fields()
-        zfield=self.zFieldName()
-        dx,dy=self._origin
+        zfield = self.zFieldName()
+        dx, dy = self._origin
         for i, line in enumerate(cs.collections):
-            level=float(cs.levels[i])
+            level = float(cs.levels[i])
             glines = []
             try:
                 for path in line.get_paths():
                     if len(path.vertices) > 1:
-                        points=[QgsPointXY(x,y) for x,y in path.vertices]
+                        points = [QgsPointXY(x, y) for x, y in path.vertices]
                         glines.append(points)
-                geom=QgsGeometry.fromMultiPolylineXY(glines)
-                geom.translate(dx,dy)
+                geom = QgsGeometry.fromMultiPolylineXY(glines)
+                geom.translate(dx, dy)
                 feat = QgsFeature(fields)
                 feat.setGeometry(geom)
-                feat['index']=i
-                feat[zfield]=level
-                feat['label']=self._levelLabel(level)
+                feat["index"] = i
+                feat[zfield] = level
+                feat["label"] = self._levelLabel(level)
                 yield feat
             except:
-                message=sys.exc_info()[1]
+                message = sys.exc_info()[1]
                 self._feedback.reportError(message)
 
-    def _rangeLabel(self,min,max):
-        op=' - '
-        lmin=''
-        lmax=''
+    def _rangeLabel(self, min, max):
+        op = " - "
+        lmin = ""
+        lmax = ""
         if np.isfinite(min):
-            lmin=self.formatLevel(min)
+            lmin = self.formatLevel(min)
         else:
-            op='< '
+            op = "< "
         if np.isfinite(max):
-            lmax=self.formatLevel(max)
+            lmax = self.formatLevel(max)
         else:
-            op='> '
-            lmax=lmin
-            lmin=''
-        return lmin+op+lmax+self._labelUnits
+            op = "> "
+            lmax = lmin
+            lmin = ""
+        return lmin + op + lmax + self._labelUnits
 
-    def buildQgsMultipolygon(self,polygon):
-        '''
+    def buildQgsMultipolygon(self, polygon):
+        """
         Construct QgsMultiPolygon from matplotlib version
-        '''
-        mpoly=[]
-        invalid=0
+        """
+        mpoly = []
+        invalid = 0
         for path in polygon.get_paths():
             path.should_simplify = False
             poly = path.to_polygons()
@@ -566,119 +587,135 @@ class ContourGenerator( QObject ):
             if len(poly[0]) < 3:
                 # Have had one vertix polygon from matplotlib!
                 continue
-            polypts=[[QgsPointXY(x,y) for x,y in p]
-                 for p in poly if len(p) > 3 ]
+            polypts = [[QgsPointXY(x, y) for x, y in p] for p in poly if len(p) > 3]
             mpoly.append(polypts)
         geom = None
         if len(mpoly) > 0:
-            geom=QgsGeometry.fromMultiPolygonXY(mpoly)
-            geom=geom.makeValid()
+            geom = QgsGeometry.fromMultiPolygonXY(mpoly)
+            geom = geom.makeValid()
         return geom
 
-    def filledContourFeatures(self ):
+    def filledContourFeatures(self):
         levels = self.levels()
-        extend=self._extendFilled
-        usegrid=self.isGridded() and self._useGrid
+        extend = self._extendFilled
+        usegrid = self.isGridded() and self._useGrid
         try:
             if usegrid:
-                gx,gy,gz=self.gridContourData()
+                gx, gy, gz = self.gridContourData()
                 cs = contourf(gx, gy, gz, levels, extend=extend)
             else:
-                trig,z=self.trigContourData()
+                trig, z = self.trigContourData()
                 cs = tricontourf(trig, z, levels, extend=extend)
         except:
             raise ContourGenerationError.fromException(sys.exc_info())
 
         levels = [float(l) for l in cs.levels]
         if ContourExtendOption.extendBelow(extend):
-            levels = np.append([-np.inf,], levels)
+            levels = np.append(
+                [
+                    -np.inf,
+                ],
+                levels,
+            )
         if ContourExtendOption.extendAbove(extend):
-            levels = np.append(levels, [np.inf,])
+            levels = np.append(
+                levels,
+                [
+                    np.inf,
+                ],
+            )
 
         fields = self.fields()
-        ninvalid=0
-        dx,dy=self._origin
-        zfieldname=self.zFieldName()
-        zminfield=zfieldname+'_min'
-        zmaxfield=zfieldname+'_max'
+        ninvalid = 0
+        dx, dy = self._origin
+        zfieldname = self.zFieldName()
+        zminfield = zfieldname + "_min"
+        zmaxfield = zfieldname + "_max"
 
         for i, polygon in enumerate(cs.collections):
-            level_min=levels[i]
-            level_max=levels[i+1]
-            label = self._rangeLabel(level_min,level_max)
+            level_min = levels[i]
+            level_max = levels[i + 1]
+            label = self._rangeLabel(level_min, level_max)
             try:
                 try:
-                    geom=self.buildQgsMultipolygon(polygon)
+                    geom = self.buildQgsMultipolygon(polygon)
                     if geom is None:
                         continue
-                    geom.translate(dx,dy)
+                    geom.translate(dx, dy)
                 except Exception as ex:
                     ninvalid += 1
                     continue
                 feat = QgsFeature(fields)
                 feat.setGeometry(geom)
-                feat['index']=i
-                feat[zminfield]=float(level_min)
-                feat[zmaxfield]=float(level_max)
-                feat['label']=label
+                feat["index"] = i
+                feat[zminfield] = float(level_min)
+                feat[zmaxfield] = float(level_max)
+                feat["label"] = label
                 yield feat
             except Exception as ex:
                 raise
                 self._feedback.reportError(sys.exc_info()[1])
 
         if ninvalid > 0:
-            self._feedback.pushInfo(tr('{0} invalid contour geometries discarded').format(ninvalid))
+            self._feedback.pushInfo(
+                tr("{0} invalid contour geometries discarded").format(ninvalid)
+            )
 
     def layerContourFeatures(self):
         levels = self.levels()
-        usegrid=self.isGridded() and self._useGrid
+        usegrid = self.isGridded() and self._useGrid
         try:
             if usegrid:
-                gx,gy,gz=self.gridContourData()
+                gx, gy, gz = self.gridContourData()
             else:
-                trig,gz=self.trigContourData()
+                trig, gz = self.trigContourData()
         except:
             raise ContourGenerationError.fromException(sys.exc_info())
 
         fields = self.fields()
-        ninvalid=0
-        dx,dy=self._origin
-        zfield=self.zFieldName()
-        zmax=np.max(gz)
-        zmax += (1.0+abs(zmax))
+        ninvalid = 0
+        dx, dy = self._origin
+        zfield = self.zFieldName()
+        zmax = np.max(gz)
+        zmax += 1.0 + abs(zmax)
         zmin = np.min(gz)
 
-        for i,level in enumerate(levels):
+        for i, level in enumerate(levels):
             if level <= zmin:
                 continue
             try:
                 if usegrid:
-                    cs = contourf(gx, gy, gz, [level,zmax], extend=ContourExtendOption.neither)
+                    cs = contourf(
+                        gx, gy, gz, [level, zmax], extend=ContourExtendOption.neither
+                    )
                 else:
-                    cs = tricontourf(trig, gz, [level,zmax], extend=ContourExtendOption.neither)
+                    cs = tricontourf(
+                        trig, gz, [level, zmax], extend=ContourExtendOption.neither
+                    )
             except:
                 raise ContourGenerationError.fromException(sys.exc_info())
             if len(cs.collections) < 1:
                 continue
-            polygon=cs.collections[0]
+            polygon = cs.collections[0]
             try:
                 try:
-                    geom=self.buildQgsMultipolygon(polygon)
+                    geom = self.buildQgsMultipolygon(polygon)
                     if geom is None:
                         continue
-                    geom.translate(dx,dy)
+                    geom.translate(dx, dy)
                 except Exception as ex:
                     ninvalid += 1
                     continue
                 feat = QgsFeature(fields)
                 feat.setGeometry(geom)
-                feat['index']=i
-                feat[zfield]=float(level)
-                feat['label']=self._levelLabel(level)
+                feat["index"] = i
+                feat[zfield] = float(level)
+                feat["label"] = self._levelLabel(level)
                 yield feat
             except Exception as ex:
                 self._feedback.reportError(ex.message)
 
         if ninvalid > 0:
-            self._feedback.pushInfo(tr('{0} invalid contour geometries discarded').format(ninvalid))
-
+            self._feedback.pushInfo(
+                tr("{0} invalid contour geometries discarded").format(ninvalid)
+            )

--- a/contour/ContourGenerator.py
+++ b/contour/ContourGenerator.py
@@ -10,7 +10,6 @@ from .ContourMethod import ContourMethodError
 qgis_qhull_fails = platform.platform().startswith("Linux")
 
 from qgis.core import (
-    Qgis,
     QgsExpression,
     QgsExpressionContext,
     QgsFeature,

--- a/contour/ContourMethod.py
+++ b/contour/ContourMethod.py
@@ -5,201 +5,233 @@ from collections import namedtuple
 
 # Need to use QObject.tr on method name, description
 
-class ContourMethodError( RuntimeError ):
+
+class ContourMethodError(RuntimeError):
     def message(self):
-        return self.args[0] if len(self.args)  > 0 else "Exception"
+        return self.args[0] if len(self.args) > 0 else "Exception"
 
-ContourMethod=namedtuple('ContourMethod','id name calc required optional description')
 
-methods=[]
+ContourMethod = namedtuple(
+    "ContourMethod", "id name calc required optional description"
+)
 
-tr=lambda x: x
+methods = []
 
-def _numberListParam( param, list ):
-    if isinstance(list,str):
-        list=list.split()
-    values=[]
-    v0=None
+tr = lambda x: x
+
+
+def _numberListParam(param, list):
+    if isinstance(list, str):
+        list = list.split()
+    values = []
+    v0 = None
     for v in list:
         try:
-            v=float(v)
+            v = float(v)
         except ValueError:
-            raise ContourMethodError(tr('Invalid value {0} in {1}').format(vs,param))
+            raise ContourMethodError(tr("Invalid value {0} in {1}").format(vs, param))
         if v0 is not None and v <= v0:
-            raise ContourMethodError(tr('Values not increasing in {0}').format(param))
+            raise ContourMethodError(tr("Values not increasing in {0}").format(param))
         values.append(v)
-        v0=v
+        v0 = v
     return np.array(values)
 
-def _paramValue( pt, param, value ):
+
+def _paramValue(pt, param, value):
     try:
-        value=pt(value)
+        value = pt(value)
     except:
-        raise ContourMethodError(tr('Invalid value for contour {0} parameter: {1}')
-                    .format(param,value))
+        raise ContourMethodError(
+            tr("Invalid value for contour {0} parameter: {1}").format(param, value)
+        )
     return value
 
-_floatParam=lambda p,v: _paramValue(float,p,v)
-_intParam=lambda p,v: _paramValue(int,p,v)
 
-_paramtypes={
-    'min': _floatParam,
-    'max': _floatParam,
-    'ncontour': _intParam,
-    'maxcontour': _intParam,
-    'interval': _floatParam,
-    'offset': _floatParam,
-    'levels': _numberListParam,
-    'mantissa': _numberListParam,
-    }
+_floatParam = lambda p, v: _paramValue(float, p, v)
+_intParam = lambda p, v: _paramValue(int, p, v)
 
-def _evalParam(p,v):
+_paramtypes = {
+    "min": _floatParam,
+    "max": _floatParam,
+    "ncontour": _intParam,
+    "maxcontour": _intParam,
+    "interval": _floatParam,
+    "offset": _floatParam,
+    "levels": _numberListParam,
+    "mantissa": _numberListParam,
+}
+
+
+def _evalParam(p, v):
     if p not in _paramtypes:
-        raise ContourMethodError(tr('Invalid contour method parameter {0}').format(p))
-    return _paramtypes[p](p,v)
+        raise ContourMethodError(tr("Invalid contour method parameter {0}").format(p))
+    return _paramtypes[p](p, v)
+
 
 def _sortedLevels(levels):
-    levels=np.array(levels)
+    levels = np.array(levels)
     levels.sort()
-    diff=np.ones(levels.shape)
-    diff[1:]=levels[1:]-levels[:-1]
-    levels=levels[diff > 0]
+    diff = np.ones(levels.shape)
+    diff[1:] = levels[1:] - levels[:-1]
+    levels = levels[diff > 0]
     return levels
 
-def _methodFunc(z,f,name,req,opt,kwa):
-    pav=[]
-    kwv={}
+
+def _methodFunc(z, f, name, req, opt, kwa):
+    pav = []
+    kwv = {}
     for k in req:
         if k not in kwa:
-            raise ContourMethodError(tr('Parameter {0} missing in {1}').format(k,name))
-        pav.append(_evalParam(k,kwa[k]))
+            raise ContourMethodError(tr("Parameter {0} missing in {1}").format(k, name))
+        pav.append(_evalParam(k, kwa[k]))
     for k in opt:
-        v=kwa.get(k)
+        v = kwa.get(k)
         if v is not None:
-            kwv[k]=_evalParam(k,v)
-    return _sortedLevels(f(z,*pav,**kwv))
+            kwv[k] = _evalParam(k, v)
+    return _sortedLevels(f(z, *pav, **kwv))
 
-def contourmethod(id=None,name=None,description=None):
-    def mf2( f ):
+
+def contourmethod(id=None, name=None, description=None):
+    def mf2(f):
         nonlocal id, name, description
-        if id is None: 
-            id=f.__name__
+        if id is None:
+            id = f.__name__
         if name is None:
-            name=id
+            name = id
         if description is None:
-            description=f.__doc__
-        sig=inspect.signature(f)
-        req=[]
-        opt=[]
+            description = f.__doc__
+        sig = inspect.signature(f)
+        req = []
+        opt = []
         for pn in sig.parameters:
-            p=sig.parameters[pn]
+            p = sig.parameters[pn]
             if p.kind == inspect.Parameter.POSITIONAL_ONLY:
                 req.append(pn)
             else:
                 opt.append(pn)
-        func=lambda z,**kwa: _methodFunc(z,f,name,req,opt,kwa)
-        methods.append(ContourMethod(id,name,func,req,opt,description))
+        func = lambda z, **kwa: _methodFunc(z, f, name, req, opt, kwa)
+        methods.append(ContourMethod(id, name, func, req, opt, description))
         return func
+
     return mf2
 
 
-def _range( z, min, max ):
+def _range(z, min, max):
     zmin = min if min is not None else np.min(z)
     zmax = max if max is not None else np.max(z)
     return zmin, zmax
 
-@contourmethod('equal','N equal intervals')
-def calcEqualContours( z, ncontour, min=None, max=None ):
-    'Equally spaced contours between min and max'
-    zmin,zmax=_range(z,min,max)
+
+@contourmethod("equal", "N equal intervals")
+def calcEqualContours(z, ncontour, min=None, max=None):
+    "Equally spaced contours between min and max"
+    zmin, zmax = _range(z, min, max)
     if zmax <= zmin:
-        raise ContourMethodError(tr('Invalid contour range - zmin=zmax'))
+        raise ContourMethodError(tr("Invalid contour range - zmin=zmax"))
     if ncontour < 1:
-        raise ContourMethodError(tr('Invalid number of contours - must be greater than 0'))
-    return np.linspace(zmin,zmax,ncontour+1)
+        raise ContourMethodError(
+            tr("Invalid number of contours - must be greater than 0")
+        )
+    return np.linspace(zmin, zmax, ncontour + 1)
 
-@contourmethod('quantile','N quantiles')
-def calcQuantileContours( z, ncontour, min=None, max=None ):
-    'Contours at percentiles of data distribution between min and max'
+
+@contourmethod("quantile", "N quantiles")
+def calcQuantileContours(z, ncontour, min=None, max=None):
+    "Contours at percentiles of data distribution between min and max"
     if min is not None:
-        z=z[z >= min]
+        z = z[z >= min]
     if max is not None:
-        z=z[z <= max]
+        z = z[z <= max]
     if len(z) < 2:
-        raise ContourMethodError(tr('Not enough z values to calculate quantiles'))
+        raise ContourMethodError(tr("Not enough z values to calculate quantiles"))
     if ncontour < 1:
-        raise ContourMethodError(tr('Invalid number of contours - must be greater than 0'))
-    pcnt=np.linspace(0.0,100.0,ncontour+1)
-    return np.percentile(z,pcnt)
-    
+        raise ContourMethodError(
+            tr("Invalid number of contours - must be greater than 0")
+        )
+    pcnt = np.linspace(0.0, 100.0, ncontour + 1)
+    return np.percentile(z, pcnt)
 
-@contourmethod('log','Logarithmic intervals')
-def calcLogContours( z, ncontour, min=None, max=None, mantissa=[1,2,5] ):
-    'Contours at up to n values 1, 2, 5 * 10^n between min and max'
-    zmin,zmax=_range(z,min,max)
+
+@contourmethod("log", "Logarithmic intervals")
+def calcLogContours(z, ncontour, min=None, max=None, mantissa=[1, 2, 5]):
+    "Contours at up to n values 1, 2, 5 * 10^n between min and max"
+    zmin, zmax = _range(z, min, max)
     if ncontour < 1:
-        raise ContourMethodError(tr('Invalid number of contours - must be greater than 0'))
+        raise ContourMethodError(
+            tr("Invalid number of contours - must be greater than 0")
+        )
     for m in mantissa:
         if m < 1.0 or m >= 10.0:
-            raise ContourMethodError(tr('Log contour mantissa must be between 1 and 10'))
+            raise ContourMethodError(
+                tr("Log contour mantissa must be between 1 and 10")
+            )
     if zmax <= 0:
-        raise ContourMethodError(tr('Cannot make log spaced contours on negative or 0 data'))
+        raise ContourMethodError(
+            tr("Cannot make log spaced contours on negative or 0 data")
+        )
     if zmin <= 0:
-        zmin=zmax/(10**(math.ceil(float(ncontour)/len(mantissa))))
-    exp0=int(math.floor(math.log10(zmin)))
-    exp1=int(math.ceil(math.log10(zmax)))
-    levels=[m*10**e for e in range(exp0,exp1+1) for m in mantissa]
-    for i,v in enumerate(levels):
+        zmin = zmax / (10 ** (math.ceil(float(ncontour) / len(mantissa))))
+    exp0 = int(math.floor(math.log10(zmin)))
+    exp1 = int(math.ceil(math.log10(zmax)))
+    levels = [m * 10**e for e in range(exp0, exp1 + 1) for m in mantissa]
+    for i, v in enumerate(levels):
         if v > zmin:
             break
     if i > 1:
-        levels=levels[i-1:]
+        levels = levels[i - 1 :]
     levels.reverse()
-    for i,v in enumerate(levels):
+    for i, v in enumerate(levels):
         if v < zmax:
             break
     if i > 1:
-        levels=levels[i-1:]
+        levels = levels[i - 1 :]
     levels.reverse()
     if len(levels) > ncontour:
         if min is not None and max is None:
-            levels=levels[:ncontour]
+            levels = levels[:ncontour]
         else:
-            levels=levels[-ncontour:]
+            levels = levels[-ncontour:]
     return levels
 
-@contourmethod('interval','Fixed contour interval')
-def calcIntervalContours( z, interval, offset=0.0,min=None, max=None, maxcontour=50):
-    'Contours at specified spacing between min and max'
+
+@contourmethod("interval", "Fixed contour interval")
+def calcIntervalContours(z, interval, offset=0.0, min=None, max=None, maxcontour=50):
+    "Contours at specified spacing between min and max"
     if interval <= 0:
         raise ContourMethodError(tr("Contour interval must be greater than zero"))
-    zmin,zmax=_range(z,min,max)
+    zmin, zmax = _range(z, min, max)
     zmin -= offset
     zmax -= offset
-    nmin=np.floor(zmin/interval)
-    nmax=np.ceil(zmax/interval)
+    nmin = np.floor(zmin / interval)
+    nmax = np.ceil(zmax / interval)
     if nmax == nmin:
         nmax += 1
     nmax += 1
-    if nmax-nmin >= maxcontour:
-        raise ContourMethodError(tr("Number of contours ({0}) exceeds maximum allowed ({1})")
-                           .format(nmax-nmin,maxcontour))
-    return np.arange(nmin,nmax)*interval+offset
+    if nmax - nmin >= maxcontour:
+        raise ContourMethodError(
+            tr("Number of contours ({0}) exceeds maximum allowed ({1})").format(
+                nmax - nmin, maxcontour
+            )
+        )
+    return np.arange(nmin, nmax) * interval + offset
 
-@contourmethod('manual','User selected contour levels')
-def parseContours( z, levels ):
-    'Contours at specified levels'
+
+@contourmethod("manual", "User selected contour levels")
+def parseContours(z, levels):
+    "Contours at specified levels"
     return levels
 
-def getMethod( id ):
+
+def getMethod(id):
     for m in methods:
         if m.id == id:
             return m
     return None
 
-def calculateLevels( z, method, **params ):
-    method=method.lower()
-    m=getMethod(method)
+
+def calculateLevels(z, method, **params):
+    method = method.lower()
+    m = getMethod(method)
     if m is not None:
-        return m.calc(z,**params)
+        return m.calc(z, **params)
     raise ContourMethodError("Invalid contouring method {0}".format(method))

--- a/contour/ContourPlugin.py
+++ b/contour/ContourPlugin.py
@@ -22,13 +22,13 @@
  ***************************************************************************/
 """
 
-__author__ = 'Chris Crook'
-__date__ = '2018-04-24'
-__copyright__ = '(C) 2018 by Chris Crook'
+__author__ = "Chris Crook"
+__date__ = "2018-04-24"
+__copyright__ = "(C) 2018 by Chris Crook"
 
 # This will get replaced with a git SHA1 when you do a git archive
 
-__revision__ = '$Format:%H$'
+__revision__ = "$Format:%H$"
 
 import os
 import sys

--- a/contour/ContourUtils.py
+++ b/contour/ContourUtils.py
@@ -1,65 +1,73 @@
-
 import numpy as np
 
-'''
+"""
 ContourUtils provide support functions for the contouring tool
-'''
+"""
 
-def _discardIndex( x, y, x0, y0, resolution, index):
-    values,ix=np.unique(((x[index]-x0)/resolution).astype(int),return_inverse=True)
-    values,iy=np.unique(((y[index]-y0)/resolution).astype(int),return_inverse=True)
-    mix=ix*values.shape[0]+iy
-    values,indices=np.unique(mix,return_inverse=True)
-    thinned=np.zeros(values.shape,dtype=int)
-    thinned[indices]=index
+
+def _discardIndex(x, y, x0, y0, resolution, index):
+    values, ix = np.unique(
+        ((x[index] - x0) / resolution).astype(int), return_inverse=True
+    )
+    values, iy = np.unique(
+        ((y[index] - y0) / resolution).astype(int), return_inverse=True
+    )
+    mix = ix * values.shape[0] + iy
+    values, indices = np.unique(mix, return_inverse=True)
+    thinned = np.zeros(values.shape, dtype=int)
+    thinned[indices] = index
     return thinned
 
-def discardDuplicatePoints(x,y,resolution,isLonLat=False):
-    '''
+
+def discardDuplicatePoints(x, y, resolution, isLonLat=False):
+    """
     Crude routine to remove duplicate points.  Somewhat randomly
-    discards points that are no longer required.  Returns indices 
+    discards points that are no longer required.  Returns indices
     of points to use.
 
     Resolution is the resolution within which points are merged
-    
+
     If isLonLat is true then x,y are assumed to be longitude/latitudes
     and are very approximately converted to metres for the test.
-    '''
+    """
     if isLonLat:
-        meanlon=np.mean(x)
-        meanlat=np.mean(y)
-        y=(y-meanlat)*100000.0
-        x=(x-meanlon)*100000.0*np.cos(np.radians(meanlat))
+        meanlon = np.mean(x)
+        meanlat = np.mean(y)
+        y = (y - meanlat) * 100000.0
+        x = (x - meanlon) * 100000.0 * np.cos(np.radians(meanlat))
 
-    x0=np.min(x)
-    y0=np.min(y)
-    index=np.arange(x.shape[0],dtype=int)
+    x0 = np.min(x)
+    y0 = np.min(y)
+    index = np.arange(x.shape[0], dtype=int)
     if resolution <= 0:
         return index
-    index=_discardIndex(x,y,x0,y0,resolution,index)
-    index=_discardIndex(x,y,x0+resolution/2,y0,resolution,index)
-    index=_discardIndex(x,y,x0,y0+resolution/2,resolution,index)
-    index=_discardIndex(x,y,x0+resolution/2,y0+resolution/2,resolution,index)
+    index = _discardIndex(x, y, x0, y0, resolution, index)
+    index = _discardIndex(x, y, x0 + resolution / 2, y0, resolution, index)
+    index = _discardIndex(x, y, x0, y0 + resolution / 2, resolution, index)
+    index = _discardIndex(
+        x, y, x0 + resolution / 2, y0 + resolution / 2, resolution, index
+    )
     return index
 
-def calcDefaultNdp( levels ):
+
+def calcDefaultNdp(levels):
     try:
-        levels=np.array(levels)
-        ldiff=levels[1:]-levels[:-1]
-        ldmin=np.min(ldiff[ldiff > 0.0])
+        levels = np.array(levels)
+        ldiff = levels[1:] - levels[:-1]
+        ldmin = np.min(ldiff[ldiff > 0.0])
         # Allow 2dp on minimum increment
         ldmin /= 100
-        ndp=0
+        ndp = 0
         while ndp < 10 and ldmin < 1.0:
             ndp += 1
             ldmin *= 10.0
         while ndp > 0:
-            factor=10**(ndp-1)
-            rerr=np.abs(levels*factor-np.round(levels*factor))
-            diff=np.max(rerr)
+            factor = 10 ** (ndp - 1)
+            rerr = np.abs(levels * factor - np.round(levels * factor))
+            diff = np.max(rerr)
             if diff >= 0.05:
                 break
             ndp -= 1
     except:
-        ndp=4 # Arbitrary!
+        ndp = 4  # Arbitrary!
     return ndp

--- a/contour/DataGridder.py
+++ b/contour/DataGridder.py
@@ -1,29 +1,30 @@
 import numpy as np
 import random
 
+
 class DataGridder:
-    '''
-    Examine a list of x,y coordinates to see if they lie on a grid, and 
+    """
+    Examine a list of x,y coordinates to see if they lie on a grid, and
     calculate the grid order and shape if they do
-    '''
+    """
 
-    def __init__( self, x=None, y=None ):
-        self.setData(x,y)
+    def __init__(self, x=None, y=None):
+        self.setData(x, y)
 
-    def setData(self,x,y):
-        '''
+    def setData(self, x, y):
+        """
         Set the x,y values to be tested
 
-        '''
-        self._x=None if x is None else x.astype(np.float64)
-        self._y=None if y is None else y.astype(np.float64)
-        self._tested=False
-        self._isValid=None
-        self._gridOrder=None
-        self._gridShape=None
+        """
+        self._x = None if x is None else x.astype(np.float64)
+        self._y = None if y is None else y.astype(np.float64)
+        self._tested = False
+        self._isValid = None
+        self._gridOrder = None
+        self._gridShape = None
 
     def calcGrid(self):
-        '''
+        """
         Calculate the grid for the current x,y values.
         Returns gridshape, gridorder
         gridshape is the shape (nrow,ncol) of the grid
@@ -31,157 +32,158 @@ class DataGridder:
 
         If the points do not lie on a grid returns gridshape as None
 
-        The grid x and y values are calculated as 
+        The grid x and y values are calculated as
             xg=x[gridorder].reshape(gridshape)
             xg=y[gridorder].reshape(gridshape)
         if gridorder is not None, else simply reshaping x and y
-        '''
+        """
         if self._x is None or self._y is None:
             return None, None
         if not self._tested:
-            self._tested=True
+            self._tested = True
             if len(self._x) > 4:
                 try:
                     self._tryGridOrdered()
-                    valid=self._gridIsValid()
+                    valid = self._gridIsValid()
                     if not valid:
                         self._tryGridReorder()
-                        valid=self._gridIsValid()
+                        valid = self._gridIsValid()
                     if not valid:
-                        self._gridShape=None
-                        self._gridOrder=None
-                    self._isValid=valid
+                        self._gridShape = None
+                        self._gridOrder = None
+                    self._isValid = valid
                 except:
                     pass
-        return self._gridShape,self._gridOrder
+        return self._gridShape, self._gridOrder
 
-    def _tryGridOrdered( self ):
-        '''
+    def _tryGridOrdered(self):
+        """
         Test if the data as ordered form a regular grid
-        '''
+        """
         # Simple test assumes grid is ordered, so dot product of vector from
         # first node to second with difference from n to n+1 should be positive
-        # except when n to n+1 jumps back to start of a new row.  So negative 
+        # except when n to n+1 jumps back to start of a new row.  So negative
         # dot products should identify start of rows, and be equally spaced in
         # data set.
-        x=self._x
-        y=self._y
+        x = self._x
+        y = self._y
         l = len(x)
-        xd=np.diff(x)
-        yd=np.diff(y)
-        ld = l-1
-        dotprod=xd[0:ld-1]*xd[1:ld]+yd[0:ld-1]*yd[1:ld]
-        ends = np.flatnonzero(dotprod<0)+2
-        if len(ends)<2:
+        xd = np.diff(x)
+        yd = np.diff(y)
+        ld = l - 1
+        dotprod = xd[0 : ld - 1] * xd[1:ld] + yd[0 : ld - 1] * yd[1:ld]
+        ends = np.flatnonzero(dotprod < 0) + 2
+        if len(ends) < 2:
             return False
         nr = ends[0]
-        nc = len(ends) // 2+1
-        if (nr >= 2) and (nc >= 2) and (nr*nc == l) and (all(ends%nr <= 1)):
-           self._gridShape=(nc,nr)
-           self._gridOrder=None
-           return True
+        nc = len(ends) // 2 + 1
+        if (nr >= 2) and (nc >= 2) and (nr * nc == l) and (all(ends % nr <= 1)):
+            self._gridShape = (nc, nr)
+            self._gridOrder = None
+            return True
         return False
 
-    def _tryGridReorder( self ):
-        '''
+    def _tryGridReorder(self):
+        """
         Test for grid by reordering rows and columns
-        '''
+        """
         # More complex test.  Attempts to identify grid rows by identifying
-        # start and end of an outside edge.  Does this by finding the point 
-        # furthest from the centre, then the point furthest from it (assumed 
+        # start and end of an outside edge.  Does this by finding the point
+        # furthest from the centre, then the point furthest from it (assumed
         # to be across the diagonal, and finally the point furthest from the
-        # line between them, assumed to be the opposite end of an edge.  Then 
+        # line between them, assumed to be the opposite end of an edge.  Then
         # uses the vector direction of the edge to sort the points into rows
         # and columns.  Finally checks that all the resultant grid cells are
         # valid, meaning not re-entrant.
-        
-        x=self._x
-        y=self._y
-        xm=np.mean(x)
-        ym=np.mean(y)
-        i0=np.argmax(np.square(x-xm)+np.square(y-ym))
-        x0=x[i0]
-        y0=y[i0]
-        u = x-x0
-        v = y-y0
-        i3=np.argmax(u*u+v*v)
-        du1=u[i3]
-        dv1=v[i3]
-        offset=u*dv1-v*du1
-        i1=np.argmax(offset)
-        i2=np.argmin(offset)
-        scl = np.sqrt(du1*du1+dv1*dv1)
+
+        x = self._x
+        y = self._y
+        xm = np.mean(x)
+        ym = np.mean(y)
+        i0 = np.argmax(np.square(x - xm) + np.square(y - ym))
+        x0 = x[i0]
+        y0 = y[i0]
+        u = x - x0
+        v = y - y0
+        i3 = np.argmax(u * u + v * v)
+        du1 = u[i3]
+        dv1 = v[i3]
+        offset = u * dv1 - v * du1
+        i1 = np.argmax(offset)
+        i2 = np.argmin(offset)
+        scl = np.sqrt(du1 * du1 + dv1 * dv1)
         u /= scl
         v /= scl
         # Transform to set the corners i0,i1,i2,i3
-        # to (-1,-1),(-1,1),(1,-1),(1,1).  Note that 
+        # to (-1,-1),(-1,1),(1,-1),(1,1).  Note that
         # uv(i0) = (0,0)
-        m=np.array([
-            [1.0,0,0,0],
-            [1.0,u[i1],v[i1],u[i1]*v[i1]],
-            [1.0,u[i2],v[i2],u[i2]*v[i2]],
-            [1.0,u[i3],v[i3],u[i3]*v[i3]],
-            ])
-        coefs=np.linalg.solve(m,np.array([[-1,-1],[1,-1],[-1,1],[1,1]]))
-        prms=np.vstack((np.ones(u.shape),u,v,u*v))
-        uv=prms.T.dot(coefs)
-        u=uv[:,0]
-        v=uv[:,1]
-        # Now guess at a spacing that will separate the 
+        m = np.array(
+            [
+                [1.0, 0, 0, 0],
+                [1.0, u[i1], v[i1], u[i1] * v[i1]],
+                [1.0, u[i2], v[i2], u[i2] * v[i2]],
+                [1.0, u[i3], v[i3], u[i3] * v[i3]],
+            ]
+        )
+        coefs = np.linalg.solve(m, np.array([[-1, -1], [1, -1], [-1, 1], [1, 1]]))
+        prms = np.vstack((np.ones(u.shape), u, v, u * v))
+        uv = prms.T.dot(coefs)
+        u = uv[:, 0]
+        v = uv[:, 1]
+        # Now guess at a spacing that will separate the
         # first row from the second...
-        vrow=1+np.min(v[v+1 > np.abs(u+1)])
-        npt=u.shape[0]
+        vrow = 1 + np.min(v[v + 1 > np.abs(u + 1)])
+        npt = u.shape[0]
         # Count the elements in the first row
-        ncol=v[v < (vrow/2-1)].shape[0]
-        nrow=int(npt/ncol)
+        ncol = v[v < (vrow / 2 - 1)].shape[0]
+        nrow = int(npt / ncol)
         # Test that row count is a divisor of the
         # number of elements
-        if nrow*ncol != npt:
+        if nrow * ncol != npt:
             return False
         # Add values to each u for each row (based on sorting of v)
         # so that u values will sort into elements across each row
         # in turn.
-        uwid=(np.max(u)-np.min(u))*2.0
-        iu=np.argsort(v)
-        urow=np.floor_divide(np.arange(npt),ncol)*uwid
-        t=np.vstack((u[iu],v[iu],urow)).T
-        urow1=u
+        uwid = (np.max(u) - np.min(u)) * 2.0
+        iu = np.argsort(v)
+        urow = np.floor_divide(np.arange(npt), ncol) * uwid
+        t = np.vstack((u[iu], v[iu], urow)).T
+        urow1 = u
         urow1[iu] += urow
         # Now have ig, which is the sort order for converting into a
         # grid
-        self._gridOrder=np.argsort(urow1)
-        self._gridShape=(nrow,ncol)
+        self._gridOrder = np.argsort(urow1)
+        self._gridShape = (nrow, ncol)
         return True
 
-    def _gridIsValid( self ):
+    def _gridIsValid(self):
         if not self._gridShape:
             return False
-        u=self._x.copy() if self._gridOrder is None else self._x[self._gridOrder]
-        v=self._y.copy() if self._gridOrder is None else self._y[self._gridOrder]
-        u=u.reshape(self._gridShape)
-        v=v.reshape(self._gridShape)
-        dudu=u[1:,:]-u[:-1,:]
-        dvdu=v[1:,:]-v[:-1,:]
-        dudv=u[:,1:]-u[:,:-1]
-        dvdv=v[:,1:]-v[:,:-1]
+        u = self._x.copy() if self._gridOrder is None else self._x[self._gridOrder]
+        v = self._y.copy() if self._gridOrder is None else self._y[self._gridOrder]
+        u = u.reshape(self._gridShape)
+        v = v.reshape(self._gridShape)
+        dudu = u[1:, :] - u[:-1, :]
+        dvdu = v[1:, :] - v[:-1, :]
+        dudv = u[:, 1:] - u[:, :-1]
+        dvdv = v[:, 1:] - v[:, :-1]
 
         # Test the cross product at each of the internal angles in turn
         # They should all have the same sign...
 
-        dotprod=dudu[:,:-1]*dvdv[:-1,:]-dvdu[:,:-1]*dudv[:-1,:]
-        imax=np.argmax(np.abs(dotprod))
+        dotprod = dudu[:, :-1] * dvdv[:-1, :] - dvdu[:, :-1] * dudv[:-1, :]
+        imax = np.argmax(np.abs(dotprod))
         sign = 1.0 if dotprod.flat[imax] > 0 else -1.0
         dotprod *= sign
         if np.any(dotprod < 0):
             return False
-        dotprod=sign*(dudu[:,1:]*dvdv[:-1,:]-dvdu[:,1:]*dudv[:-1,:])
+        dotprod = sign * (dudu[:, 1:] * dvdv[:-1, :] - dvdu[:, 1:] * dudv[:-1, :])
         if np.any(dotprod < 0):
             return False
-        dotprod=sign*(dudu[:,1:]*dvdv[1:,:]-dvdu[:,1:]*dudv[1:,:])
+        dotprod = sign * (dudu[:, 1:] * dvdv[1:, :] - dvdu[:, 1:] * dudv[1:, :])
         if np.any(dotprod < 0):
             return False
-        dotprod=sign*(dudu[:,:-1]*dvdv[1:,:]-dvdu[:,:-1]*dudv[1:,:])
+        dotprod = sign * (dudu[:, :-1] * dvdv[1:, :] - dvdu[:, :-1] * dudv[1:, :])
         if np.any(dotprod < 0):
-           return False
+            return False
         return True
-

--- a/contour/__init__.py
+++ b/contour/__init__.py
@@ -22,9 +22,9 @@
  This script initializes the plugin, making it known to QGIS.
 """
 
-__author__ = 'Chris Crook'
-__date__ = '2018-04-24'
-__copyright__ = '(C) 2018 by Chris Crook'
+__author__ = "Chris Crook"
+__date__ = "2018-04-24"
+__copyright__ = "(C) 2018 by Chris Crook"
 
 
 # noinspection PyPep8Naming
@@ -36,4 +36,5 @@ def classFactory(iface):  # pylint: disable=invalid-name
     """
     #
     from .ContourPlugin import ContourPlugin
+
     return ContourPlugin(iface)

--- a/contour/buildtrig_qhull_workaround.py
+++ b/contour/buildtrig_qhull_workaround.py
@@ -7,7 +7,6 @@ from matplotlib.tri import Triangulation
 if len(sys.argv) != 3:
     sys.exit(1)
 
-xy=np.load(sys.argv[1])
-trig=Triangulation(xy[0],xy[1])
-np.save(sys.argv[2],trig.triangles)
-
+xy = np.load(sys.argv[1])
+trig = Triangulation(xy[0], xy[1])
+np.save(sys.argv[2], trig.triangles)

--- a/contour/metadata.txt
+++ b/contour/metadata.txt
@@ -4,7 +4,7 @@
 name=Contour plugin
 qgisMinimumVersion=3.0
 description=Generates contours from point layer
-version=2.0.13
+version=2.0.14
 
 about=Generate a contour layer based on an attribute of a point vector layer. 
 

--- a/contour/resources.py
+++ b/contour/resources.py
@@ -169,18 +169,25 @@ qt_resource_struct_v2 = b"\
 \x00\x00\x01\x63\x95\x63\xf8\xb8\
 "
 
-qt_version = QtCore.qVersion().split('.')
-if qt_version < ['5', '8', '0']:
+qt_version = QtCore.qVersion().split(".")
+if qt_version < ["5", "8", "0"]:
     rcc_version = 1
     qt_resource_struct = qt_resource_struct_v1
 else:
     rcc_version = 2
     qt_resource_struct = qt_resource_struct_v2
 
+
 def qInitResources():
-    QtCore.qRegisterResourceData(rcc_version, qt_resource_struct, qt_resource_name, qt_resource_data)
+    QtCore.qRegisterResourceData(
+        rcc_version, qt_resource_struct, qt_resource_name, qt_resource_data
+    )
+
 
 def qCleanupResources():
-    QtCore.qUnregisterResourceData(rcc_version, qt_resource_struct, qt_resource_name, qt_resource_data)
+    QtCore.qUnregisterResourceData(
+        rcc_version, qt_resource_struct, qt_resource_name, qt_resource_data
+    )
+
 
 qInitResources()


### PR DESCRIPTION
This mainly addresses the issue caused by changes in matplotlib contouring functions at version 3.8.0 which result in corrupt line contours (adds lines joining each contour segment to the next).  This change does not appear to have altered the behaviour of filled contours.  

See https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.8.0.html 

> Prior to this release, [ContourSet](https://matplotlib.org/stable/api/contour_api.html#matplotlib.contour.ContourSet) (the object returned by [contour](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.contour.html#matplotlib.axes.Axes.contour)) was a custom object holding multiple [Collection](https://matplotlib.org/stable/api/collections_api.html#matplotlib.collections.Collection)s (and not an [Artist](https://matplotlib.org/stable/api/artist_api.html#matplotlib.artist.Artist)) -- one collection per level, each connected component of that level's contour being an entry in the corresponding collection.
> 
> [ContourSet](https://matplotlib.org/stable/api/contour_api.html#matplotlib.contour.ContourSet) is now instead a plain [Collection](https://matplotlib.org/stable/api/collections_api.html#matplotlib.collections.Collection) (and thus an [Artist](https://matplotlib.org/stable/api/artist_api.html#matplotlib.artist.Artist)). The collection contains a single path per contour level; this path may be non-continuous in case there are multiple connected components.

Also fixed is the "AttributeError: 'NoneType' object has no attribute 'sourceCrs'" error when reloading an existing contour layer (ie layer selected when the dialog box is opened and generating contours).

