### PR TITLE
prep for QGIS4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:pyenv"
+}

--- a/contour/ContourDialog.py
+++ b/contour/ContourDialog.py
@@ -20,10 +20,10 @@
 #       Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #       MA 02110-1301, USA.
 
-from PyQt5.QtCore import *
-from PyQt5.QtWidgets import *
-from PyQt5.QtGui import *
-from PyQt5.QtXml import QDomDocument
+from qgis.PyQt.QtCore import *
+from qgis.PyQt.QtWidgets import *
+from qgis.PyQt.QtGui import *
+from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import *
 from qgis.gui import QgsMessageBar
 from . import resources
@@ -78,7 +78,7 @@ class ContourDialogPlugin:
 
         QgsMessageLog.logMessage(
             f"Contour plugin is using matplotlib version {mpl.__version__} and numpy version {np.__version__}",
-            level=Qgis.Info,
+            level=Qgis.MessageLevel.Info,
         )
         self.action = QAction(
             QIcon(":/plugins/contour/contour.png"), "Contour", self._iface.mainWindow()
@@ -99,7 +99,7 @@ class ContourDialogPlugin:
     def run(self):
         try:
             dlg = ContourDialog(self._iface)
-            dlg.exec_()
+            dlg.exec()
         except ContourError:
             QMessageBox.warning(
                 self._iface.mainWindow(), tr("Contour error"), str(sys.exc_info()[1])
@@ -150,9 +150,9 @@ class ContourDialog(QDialog, Ui_ContourDialog):
         self.uSelectedOnly.setChecked(False)
         self.uSelectedOnly.setEnabled(False)
         self.uUseGrid.setEnabled(False)
-        self.uSourceLayer.setFilters(QgsMapLayerProxyModel.PointLayer)
+        self.uSourceLayer.setFilters(QgsMapLayerProxyModel.Filter.PointLayer)
         self.uDataField.setExpressionDialogTitle(tr("Value to contour"))
-        self.uDataField.setFilters(QgsFieldProxyModel.Numeric)
+        self.uDataField.setFilters(QgsFieldProxyModel.Filter.Numeric)
         self.uNContour.setMinimum(2)
         self.uNContour.setValue(10)
         self.uSetMinimum.setChecked(False)
@@ -433,7 +433,7 @@ class ContourDialog(QDialog, Ui_ContourDialog):
     def editLevel(self, item=None):
         if not self._canEditList:
             return
-        if item is None or QApplication.keyboardModifiers() & Qt.ShiftModifier:
+        if item is None or QApplication.keyboardModifiers() & Qt.KeyboardModifier.ShiftModifier:
             list = self.uLevelsList
             val = " ".join([list.item(i).text() for i in range(0, list.count())])
         else:
@@ -444,7 +444,7 @@ class ContourDialog(QDialog, Ui_ContourDialog):
             tr("Enter a single level to replace this one")
             + "\n"
             + tr("or a space separated list of levels to replace all"),
-            QLineEdit.Normal,
+            QLineEdit.EchoMode.Normal,
             val,
         )
         if ok:
@@ -595,8 +595,8 @@ class ContourDialog(QDialog, Ui_ContourDialog):
             self,
             tr("Replace contour layers"),
             message,
-            QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel,
-            QMessageBox.Cancel,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Cancel,
         )
 
     def addContours(self):
@@ -606,14 +606,14 @@ class ContourDialog(QDialog, Ui_ContourDialog):
             replaceContourId = ""
             for set in self.candidateReplacementSets():
                 result = self.confirmReplaceSet(set)
-                if result == QMessageBox.Cancel:
+                if result == QMessageBox.StandardButton.Cancel:
                     return
-                if result == QMessageBox.Yes:
+                if result == QMessageBox.StandardButton.Yes:
                     self._replaceLayerSet = set
                     replaceContourId = self.layerSetContourId(set)
                     break
             try:
-                QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+                QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
                 self.setLabelFormat()
                 if self.uLinesContours.isChecked() or self.uBoth.isChecked():
                     self.makeContourLayer(ContourType.line)
@@ -657,7 +657,7 @@ class ContourDialog(QDialog, Ui_ContourDialog):
     def sourceLayers(self):
         for layer in list(QgsProject.instance().mapLayers().values()):
             if (layer.type() == layer.VectorLayer) and (
-                layer.geometryType() == QgsWkbTypes.PointGeometry
+                layer.geometryType() == QgsWkbTypes.GeometryType.PointGeometry
             ):
                 yield layer
 
@@ -668,7 +668,7 @@ class ContourDialog(QDialog, Ui_ContourDialog):
     def clearLayer(self, layer):
         pl = layer.dataProvider()
         request = QgsFeatureRequest()
-        request.setFlags(QgsFeatureRequest.NoGeometry)
+        request.setFlags(QgsFeatureRequest.Flag.NoGeometry)
         request.setSubsetOfAttributes([])
         fids = []
         for f in pl.getFeatures(request):

--- a/contour/ContourDialogUi.py
+++ b/contour/ContourDialogUi.py
@@ -2,11 +2,11 @@
 
 # Form implementation generated from reading ui file 'ContourDialogUi.ui'
 #
-# Created by: PyQt5 UI code generator 5.5.1
+# Created by: qgis.PyQt UI code generator 5.5.1
 #
 # WARNING! All changes made in this file will be lost!
 
-from PyQt5 import QtCore, QtGui, QtWidgets
+from qgis.PyQt import QtCore, QtGui, QtWidgets
 
 
 class Ui_ContourDialog(object):

--- a/contour/ContourDialogUi.py
+++ b/contour/ContourDialogUi.py
@@ -12,13 +12,13 @@ from qgis.PyQt import QtCore, QtGui, QtWidgets
 class Ui_ContourDialog(object):
     def setupUi(self, ContourDialog):
         ContourDialog.setObjectName("ContourDialog")
-        ContourDialog.setWindowModality(QtCore.Qt.NonModal)
+        ContourDialog.setWindowModality(QtCore.Qt.WindowModality.NonModal)
         ContourDialog.resize(655, 742)
         ContourDialog.setSizeGripEnabled(True)
         self.verticalLayout = QtWidgets.QVBoxLayout(ContourDialog)
         self.verticalLayout.setObjectName("verticalLayout")
         self.scrollArea_2 = QtWidgets.QScrollArea(ContourDialog)
-        self.scrollArea_2.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.scrollArea_2.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.scrollArea_2.setWidgetResizable(True)
         self.scrollArea_2.setObjectName("scrollArea_2")
         self.scrollAreaWidgetContents_2 = QtWidgets.QWidget()
@@ -32,28 +32,28 @@ class Ui_ContourDialog(object):
         self.gridLayout.setObjectName("gridLayout")
         self.formLayout_2 = QtWidgets.QFormLayout()
         self.formLayout_2.setFieldGrowthPolicy(
-            QtWidgets.QFormLayout.AllNonFixedFieldsGrow
+            QtWidgets.QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow
         )
         self.formLayout_2.setContentsMargins(-1, 0, -1, -1)
         self.formLayout_2.setObjectName("formLayout_2")
         self.label_3 = QtWidgets.QLabel(self.groupBox_2)
         self.label_3.setObjectName("label_3")
-        self.formLayout_2.setWidget(1, QtWidgets.QFormLayout.LabelRole, self.label_3)
+        self.formLayout_2.setWidget(1, QtWidgets.QFormLayout.ItemRole.LabelRole, self.label_3)
         self.uSourceLayer = QgsMapLayerComboBox(self.groupBox_2)
         self.uSourceLayer.setObjectName("uSourceLayer")
         self.formLayout_2.setWidget(
-            1, QtWidgets.QFormLayout.FieldRole, self.uSourceLayer
+            1, QtWidgets.QFormLayout.ItemRole.FieldRole, self.uSourceLayer
         )
         self.label_4 = QtWidgets.QLabel(self.groupBox_2)
         self.label_4.setObjectName("label_4")
-        self.formLayout_2.setWidget(3, QtWidgets.QFormLayout.LabelRole, self.label_4)
+        self.formLayout_2.setWidget(3, QtWidgets.QFormLayout.ItemRole.LabelRole, self.label_4)
         self.uDataField = QgsFieldExpressionWidget(self.groupBox_2)
         self.uDataField.setObjectName("uDataField")
-        self.formLayout_2.setWidget(3, QtWidgets.QFormLayout.FieldRole, self.uDataField)
+        self.formLayout_2.setWidget(3, QtWidgets.QFormLayout.ItemRole.FieldRole, self.uDataField)
         self.uSelectedOnly = QtWidgets.QCheckBox(self.groupBox_2)
         self.uSelectedOnly.setObjectName("uSelectedOnly")
         self.formLayout_2.setWidget(
-            4, QtWidgets.QFormLayout.FieldRole, self.uSelectedOnly
+            4, QtWidgets.QFormLayout.ItemRole.FieldRole, self.uSelectedOnly
         )
         self.gridLayout.addLayout(self.formLayout_2, 1, 0, 1, 1)
         self.horizontalLayout = QtWidgets.QHBoxLayout()
@@ -85,7 +85,7 @@ class Ui_ContourDialog(object):
         self.uUseGrid.setObjectName("uUseGrid")
         self.horizontalLayout.addWidget(self.uUseGrid)
         spacerItem = QtWidgets.QSpacerItem(
-            40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum
+            40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum
         )
         self.horizontalLayout.addItem(spacerItem)
         self.gridLayout.addLayout(self.horizontalLayout, 3, 0, 1, 1)
@@ -113,12 +113,12 @@ class Ui_ContourDialog(object):
         self.uLayerContours.setObjectName("uLayerContours")
         self.horizontalLayout_7.addWidget(self.uLayerContours)
         spacerItem1 = QtWidgets.QSpacerItem(
-            40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum
+            40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum
         )
         self.horizontalLayout_7.addItem(spacerItem1)
         self.gridLayout_2.addLayout(self.horizontalLayout_7, 0, 0, 1, 3)
         spacerItem2 = QtWidgets.QSpacerItem(
-            20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding
+            20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding
         )
         self.gridLayout_2.addItem(spacerItem2, 10, 1, 1, 1)
         self.label_5 = QtWidgets.QLabel(self.groupBox)
@@ -129,7 +129,7 @@ class Ui_ContourDialog(object):
         self.gridLayout_2.addWidget(self.label, 3, 0, 1, 1)
         self.uNContour = QtWidgets.QSpinBox(self.groupBox)
         sizePolicy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed
         )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -145,7 +145,7 @@ class Ui_ContourDialog(object):
         self.gridLayout_2.addWidget(self.label_10, 8, 0, 1, 1)
         self.uExtend = QtWidgets.QComboBox(self.groupBox)
         sizePolicy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed
         )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -161,14 +161,14 @@ class Ui_ContourDialog(object):
         self.horizontalLayout_6.addWidget(self.uSetMaximum)
         self.uMaxContour = QtWidgets.QDoubleSpinBox(self.groupBox)
         sizePolicy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed
         )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.uMaxContour.sizePolicy().hasHeightForWidth())
         self.uMaxContour.setSizePolicy(sizePolicy)
         self.uMaxContour.setLocale(
-            QtCore.QLocale(QtCore.QLocale.C, QtCore.QLocale.AnyCountry)
+            QtCore.QLocale("C")
         )
         self.uMaxContour.setDecimals(4)
         self.uMaxContour.setMinimum(-999999999.0)
@@ -181,7 +181,7 @@ class Ui_ContourDialog(object):
         self.gridLayout_2.addWidget(self.label_7, 1, 0, 1, 1)
         self.uMethod = QtWidgets.QComboBox(self.groupBox)
         sizePolicy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed
         )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -198,14 +198,14 @@ class Ui_ContourDialog(object):
         self.horizontalLayout_5.addWidget(self.uSetMinimum)
         self.uMinContour = QtWidgets.QDoubleSpinBox(self.groupBox)
         sizePolicy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed
         )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.uMinContour.sizePolicy().hasHeightForWidth())
         self.uMinContour.setSizePolicy(sizePolicy)
         self.uMinContour.setLocale(
-            QtCore.QLocale(QtCore.QLocale.C, QtCore.QLocale.AnyCountry)
+            QtCore.QLocale("C")
         )
         self.uMinContour.setDecimals(4)
         self.uMinContour.setMinimum(-999999999.0)
@@ -218,7 +218,7 @@ class Ui_ContourDialog(object):
         self.gridLayout_2.addWidget(self.label_6, 7, 0, 1, 1)
         self.uContourInterval = QtWidgets.QDoubleSpinBox(self.groupBox)
         sizePolicy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Fixed
         )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -227,7 +227,7 @@ class Ui_ContourDialog(object):
         )
         self.uContourInterval.setSizePolicy(sizePolicy)
         self.uContourInterval.setLocale(
-            QtCore.QLocale(QtCore.QLocale.C, QtCore.QLocale.AnyCountry)
+            QtCore.QLocale("C")
         )
         self.uContourInterval.setDecimals(4)
         self.uContourInterval.setMinimum(-999999999.0)
@@ -239,14 +239,14 @@ class Ui_ContourDialog(object):
         self.gridLayout_2.addWidget(self.label_15, 2, 0, 1, 1)
         self.uLevelsList = QtWidgets.QListWidget(self.groupBox)
         sizePolicy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Preferred
+            QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred
         )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.uLevelsList.sizePolicy().hasHeightForWidth())
         self.uLevelsList.setSizePolicy(sizePolicy)
         self.uLevelsList.setLocale(
-            QtCore.QLocale(QtCore.QLocale.C, QtCore.QLocale.AnyCountry)
+            QtCore.QLocale("C")
         )
         self.uLevelsList.setObjectName("uLevelsList")
         self.gridLayout_2.addWidget(self.uLevelsList, 1, 2, 10, 1)
@@ -260,16 +260,16 @@ class Ui_ContourDialog(object):
         self.formLayout.setObjectName("formLayout")
         self.label_8 = QtWidgets.QLabel(self.groupBox_3)
         self.label_8.setObjectName("label_8")
-        self.formLayout.setWidget(0, QtWidgets.QFormLayout.LabelRole, self.label_8)
+        self.formLayout.setWidget(0, QtWidgets.QFormLayout.ItemRole.LabelRole, self.label_8)
         self.uOutputName = QtWidgets.QLineEdit(self.groupBox_3)
         self.uOutputName.setObjectName("uOutputName")
-        self.formLayout.setWidget(0, QtWidgets.QFormLayout.FieldRole, self.uOutputName)
+        self.formLayout.setWidget(0, QtWidgets.QFormLayout.ItemRole.FieldRole, self.uOutputName)
         self.horizontalLayout_2 = QtWidgets.QHBoxLayout()
         self.horizontalLayout_2.setContentsMargins(0, 0, -1, -1)
         self.horizontalLayout_2.setObjectName("horizontalLayout_2")
         self.uPrecision = QtWidgets.QSpinBox(self.groupBox_3)
         sizePolicy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed
+            QtWidgets.QSizePolicy.Policy.Fixed, QtWidgets.QSizePolicy.Policy.Fixed
         )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -294,15 +294,15 @@ class Ui_ContourDialog(object):
         self.uLabelUnits.setObjectName("uLabelUnits")
         self.horizontalLayout_2.addWidget(self.uLabelUnits)
         spacerItem3 = QtWidgets.QSpacerItem(
-            40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum
+            40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum
         )
         self.horizontalLayout_2.addItem(spacerItem3)
         self.formLayout.setLayout(
-            1, QtWidgets.QFormLayout.FieldRole, self.horizontalLayout_2
+            1, QtWidgets.QFormLayout.ItemRole.FieldRole, self.horizontalLayout_2
         )
         self.label_9 = QtWidgets.QLabel(self.groupBox_3)
         self.label_9.setObjectName("label_9")
-        self.formLayout.setWidget(1, QtWidgets.QFormLayout.LabelRole, self.label_9)
+        self.formLayout.setWidget(1, QtWidgets.QFormLayout.ItemRole.LabelRole, self.label_9)
         self.horizontalLayout_4 = QtWidgets.QHBoxLayout()
         self.horizontalLayout_4.setContentsMargins(-1, -1, -1, 0)
         self.horizontalLayout_4.setObjectName("horizontalLayout_4")
@@ -317,16 +317,16 @@ class Ui_ContourDialog(object):
         self.uReverseRamp.setObjectName("uReverseRamp")
         self.horizontalLayout_4.addWidget(self.uReverseRamp)
         spacerItem4 = QtWidgets.QSpacerItem(
-            40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum
+            40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum
         )
         self.horizontalLayout_4.addItem(spacerItem4)
         self.horizontalLayout_4.setStretch(1, 1)
         self.formLayout.setLayout(
-            2, QtWidgets.QFormLayout.FieldRole, self.horizontalLayout_4
+            2, QtWidgets.QFormLayout.ItemRole.FieldRole, self.horizontalLayout_4
         )
         self.label_13 = QtWidgets.QLabel(self.groupBox_3)
         self.label_13.setObjectName("label_13")
-        self.formLayout.setWidget(2, QtWidgets.QFormLayout.LabelRole, self.label_13)
+        self.formLayout.setWidget(2, QtWidgets.QFormLayout.ItemRole.LabelRole, self.label_13)
         self.gridLayout_4.addLayout(self.formLayout, 0, 0, 1, 1)
         self.verticalLayout_2.addWidget(self.groupBox_3)
         self.verticalLayout_2.setStretch(1, 1)
@@ -334,7 +334,7 @@ class Ui_ContourDialog(object):
         self.verticalLayout.addWidget(self.scrollArea_2)
         self.uMessageBar = QgsMessageBar(ContourDialog)
         sizePolicy = QtWidgets.QSizePolicy(
-            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Preferred
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Preferred
         )
         sizePolicy.setHorizontalStretch(1)
         sizePolicy.setVerticalStretch(0)
@@ -348,7 +348,7 @@ class Ui_ContourDialog(object):
         self.horizontalLayout_8.setObjectName("horizontalLayout_8")
         self.progressBar = QtWidgets.QProgressBar(ContourDialog)
         self.progressBar.setProperty("value", 0)
-        self.progressBar.setAlignment(QtCore.Qt.AlignCenter)
+        self.progressBar.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         self.progressBar.setTextVisible(True)
         self.progressBar.setObjectName("progressBar")
         self.horizontalLayout_8.addWidget(self.progressBar)

--- a/contour/ContourDialogUi.ui
+++ b/contour/ContourDialogUi.ui
@@ -3,7 +3,7 @@
  <class>ContourDialog</class>
  <widget class="QDialog" name="ContourDialog">
   <property name="windowModality">
-   <enum>Qt::NonModal</enum>
+   <enum>Qt::WindowModality::NonModal</enum>
   </property>
   <property name="geometry">
    <rect>
@@ -23,7 +23,7 @@
    <item>
     <widget class="QScrollArea" name="scrollArea_2">
      <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
+      <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -47,7 +47,7 @@
           <item row="1" column="0">
            <layout class="QFormLayout" name="formLayout_2">
             <property name="fieldGrowthPolicy">
-             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+             <enum>QFormLayout::FieldGrowthPolicy::AllNonFixedFieldsGrow</enum>
             </property>
             <property name="topMargin">
              <number>0</number>

--- a/contour/ContourGenerator.py
+++ b/contour/ContourGenerator.py
@@ -20,7 +20,7 @@ from qgis.core import (
     QgsFields,
     QgsWkbTypes,
 )
-from PyQt5.QtCore import QObject, QVariant, QCoreApplication
+from qgis.PyQt.QtCore import QObject, QVariant, QCoreApplication
 
 _mplAvailable = False
 try:
@@ -102,9 +102,9 @@ class ContourType:
     }
 
     _wkbtype = {
-        line: QgsWkbTypes.MultiLineString,
-        filled: QgsWkbTypes.MultiPolygon,
-        layer: QgsWkbTypes.MultiPolygon,
+        line: QgsWkbTypes.Type.MultiLineString,
+        filled: QgsWkbTypes.Type.MultiPolygon,
+        layer: QgsWkbTypes.Type.MultiPolygon,
     }
 
     def types():
@@ -306,7 +306,7 @@ class ContourGenerator(QObject):
                         raise ContourError(tr("Z value {0} is not number").format(zval))
                     if zval is not None:
                         fgeom = feat.geometry()
-                        if QgsWkbTypes.flatType(fgeom.wkbType()) != QgsWkbTypes.Point:
+                        if QgsWkbTypes.flatType(fgeom.wkbType()) != QgsWkbTypes.Type.Point:
                             raise ContourError(
                                 tr(
                                     "Invalid geometry type for contouring - must be point geometry"

--- a/contour/ContourGeneratorAlgorithm.py
+++ b/contour/ContourGeneratorAlgorithm.py
@@ -31,8 +31,8 @@ __copyright__ = "(C) 2018 by Chris Crook"
 __revision__ = "$Format:%H$"
 
 import os.path
-from PyQt5.QtCore import QCoreApplication, QUrl
-from PyQt5.QtGui import QIcon
+from qgis.PyQt.QtCore import QCoreApplication, QUrl
+from qgis.PyQt.QtGui import QIcon
 from qgis.core import (
     QgsProcessing,
     QgsFeatureSink,
@@ -135,7 +135,7 @@ class ContourGeneratorAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.PrmInputLayer,
                 tr("Input point layer"),
-                [QgsProcessing.TypeVectorPoint],
+                [QgsProcessing.SourceType.TypeVectorPoint],
             )
         )
 
@@ -156,7 +156,7 @@ class ContourGeneratorAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.PrmDuplicatePointTolerance,
                 tr("Duplicate point tolerance"),
-                QgsProcessingParameterNumber.Double,
+                QgsProcessingParameterNumber.Type.Double,
                 minValue=0.0,
                 defaultValue=0.0,
                 optional=True,
@@ -197,7 +197,7 @@ class ContourGeneratorAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.PrmMinContourValue,
                 tr("Minimum contour level (omit to use data minimum)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 optional=True,
             )
         )
@@ -206,7 +206,7 @@ class ContourGeneratorAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.PrmMaxContourValue,
                 tr("Maximum contour level (omit to use data maximum)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 optional=True,
             )
         )
@@ -215,7 +215,7 @@ class ContourGeneratorAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.PrmContourInterval,
                 tr("Contour interval"),
-                QgsProcessingParameterNumber.Double,
+                QgsProcessingParameterNumber.Type.Double,
                 minValue=0.0,
                 defaultValue=1.0,
                 optional=True,
@@ -238,7 +238,7 @@ class ContourGeneratorAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.PrmLabelDecimalPlaces,
                 tr("Label decimal places (-1 for auto)"),
-                QgsProcessingParameterNumber.Integer,
+                QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=-1,
                 minValue=-1,
                 maxValue=10,
@@ -330,7 +330,7 @@ class ContourGeneratorAlgorithm(QgsProcessingAlgorithm):
 
             # Add features to the sink
             for feature in generator.contourFeatures():
-                sink.addFeature(feature, QgsFeatureSink.FastInsert)
+                sink.addFeature(feature, QgsFeatureSink.Flag.FastInsert)
 
         except (ContourError, ContourMethodError) as ex:
             feedback.reportError(ex.message())
@@ -350,7 +350,7 @@ class ContourGeneratorAlgorithm(QgsProcessingAlgorithm):
         )
         if not os.path.exists(file):
             return ""
-        return QUrl.fromLocalFile(file).toString(QUrl.FullyEncoded)
+        return QUrl.fromLocalFile(file).toString(QUrl.ComponentFormattingOption.FullyEncoded)
 
     def displayName(self):
         return tr("Generate Contours")

--- a/contour/ContourGeneratorProvider.py
+++ b/contour/ContourGeneratorProvider.py
@@ -26,7 +26,7 @@ __author__ = "Chris Crook"
 __date__ = "2018-04-24"
 __copyright__ = "(C) 2018 by Chris Crook"
 
-from PyQt5.QtGui import QIcon
+from qgis.PyQt.QtGui import QIcon
 from qgis.core import QgsProcessingProvider
 from .ContourGeneratorAlgorithm import ContourGeneratorAlgorithm
 from . import resources

--- a/contour/metadata.txt
+++ b/contour/metadata.txt
@@ -32,3 +32,7 @@ experimental=False
 deprecated=False
 
 hasProcessingProvider=yes
+
+# Added by Qt5 to Qt6 migration script
+supportsQt6=True
+qgisMaximumVersion=4.99

--- a/contour/resources.py
+++ b/contour/resources.py
@@ -2,11 +2,11 @@
 
 # Resource object code
 #
-# Created by: The Resource Compiler for PyQt5 (Qt v5.9.5)
+# Created by: The Resource Compiler for qgis.PyQt
 #
 # WARNING! All changes made in this file will be lost!
 
-from PyQt5 import QtCore
+from qgis.PyQt import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x07\xae\


### PR DESCRIPTION
updated the qt5 attributes to qt6 attributes in the various python files. 
added supportsQt6=True and qgisMaximumversion=4.99 to metadata.txt

Tested in my Qgis4 install on a project that uses the plugin in a model builder. 
Also tested the UI with the same input data and played with the various options. 
But please please test some more before putting it on the Qgis plugin website.